### PR TITLE
Phase1 計画文書（02-10）と構造検証テストを追加

### DIFF
--- a/docs/plans/02-phase1-db-schema-and-migrations.md
+++ b/docs/plans/02-phase1-db-schema-and-migrations.md
@@ -1,0 +1,125 @@
+---
+title: Phase 1.1 DBスキーマ・マイグレーション基盤
+phase: 1
+task_id: 1.1
+status: Draft
+priority: 高
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.1 DBスキーマ・マイグレーション基盤
+
+## タスク概要
+
+`docs/plans/00-initial-design.md` §4.2 の DDL を Alembic マイグレーションへ落とし込み、PostgreSQL 16 上で **冪等に適用できる初期スキーマ基盤**を整備する。Phase1 のすべての後続タスク（共通型、アダプタ、取込CLI、月次サマリ SQL）が依存する土台であり、Phase1 完了条件 (a)「`alembic upgrade head` が冪等に実行できる」を直接満たす。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.1, §3.1 完了条件 (a), `docs/design/01-data-model.md`。
+
+## 目的・背景
+
+### 目的
+
+- 初期設計書 §4.2 が定義する 7 テーブル（`institutions` / `accounts` / `categories` / `transactions` / `holdings` / `balance_snapshots` / `categorization_rules`）を Alembic で管理可能なスキーマとして実装する。
+- 取引の冪等性を保証する `transactions.hash` の UNIQUE 制約と、金額の厳密表現を保証する NUMERIC 型を、最初のマイグレーションから正しく組み込む。
+- 後続のアダプタ・CLI・SQL クエリが「スキーマは確定済み」という前提で実装に集中できる状態を作る。
+
+### 背景
+
+- Phase1 のすべてのタスクが本タスク完了を起点として進行するため、最上流のクリティカルパス上にある（`01-development-plan.md` §5）。
+- 関連 ADR は ADR-004（PostgreSQL 16 + JSONB）, ADR-005（NUMERIC 型採用）, ADR-006（hash UNIQUE） の 3 本で、いずれも本タスクの実装で初めて具体化される。
+- マイグレーションの粒度は「institutions / accounts」「categories」「transactions」「holdings / balance_snapshots」「categorization_rules」の 5 ファイルに分割し、1 PR 内で 5 コミットに分けて履歴をたどりやすくする（`01-development-plan.md` §4.1 補足）。
+
+## スコープ
+
+### 含む
+
+- 既存 Alembic 設定（`alembic.ini`, `alembic/env.py` は実装済み・`script_location = alembic`）への versions 追加。
+- 7 テーブルの初期スキーマ migration 一式（5 ファイル分割）を `alembic/versions/` 配下に追加。
+- `transactions.hash` の UNIQUE インデックス、`amount` の NUMERIC 型と CHECK 制約、`category_source` ENUM の制約定義。
+- マイグレーションの冪等性検証（2 回連続適用が無害である）。
+- スキーマ存在検証用ユニットテストフィクスチャ（dev 依存に宣言済みの `testcontainers` を用いてテスト用 Postgres コンテナを起動、または既存 `tests/_compose_utils.py` で読み込む `docker-compose.test.yml` 経由で利用）。
+
+### 含まない
+
+- アプリ層の ORM モデル（dataclass / pydantic は Phase 1.2 で扱う）。
+- データ投入用 CLI / アダプタ（Phase 1.3〜1.6）。
+- ダウングレード（`alembic downgrade`）の実運用検証（Phase 4 のリリース時に総合確認）。
+- バックアップ / リストア手順（ADR-012, Phase 4）。
+
+## 依存タスク
+
+- なし（Phase1 最上流タスク。`docs/plans/01-development-plan.md` §5 のクリティカルパス起点）。
+
+## 後続タスク
+
+- `03-phase1-domain-types.md`（Phase 1.2 共通型: 本タスクのスキーマに対応する dataclass を定義）。
+- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: 共通型を介して間接依存）。
+- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: `transactions` テーブル定義に依存）。
+
+## 対象ファイル/モジュール
+
+| パス | 区分 | 役割 |
+|---|---|---|
+| `alembic.ini` | 既存・参照のみ | Alembic 設定。`script_location = alembic`、`sqlalchemy.url = ${DATABASE_URL}` プレースホルダ。本タスクでは原則変更しない |
+| `alembic/env.py` | 既存・参照のみ | マイグレーション実行コンテキスト。`resolve_database_url()` 実装済。`target_metadata` を本タスクで bind するなら必要に応じて改修 |
+| `alembic/versions/0001_create_institutions_and_accounts.py` | 新規 | 機関・口座テーブル |
+| `alembic/versions/0002_create_categories.py` | 新規 | カテゴリ階層 |
+| `alembic/versions/0003_create_transactions.py` | 新規 | 取引テーブル + `hash` UNIQUE |
+| `alembic/versions/0004_create_holdings_and_snapshots.py` | 新規 | 保有銘柄・残高スナップショット |
+| `alembic/versions/0005_create_categorization_rules.py` | 新規 | カテゴリルール |
+| `src/kakeibo/db/__init__.py` | 新規 | DB 接続ヘルパ（テスト用エンジン共有） |
+| `tests/unit/db/test_schema.py` | 新規 | 全テーブル・全制約の存在検証 |
+| `tests/unit/db/test_migration_idempotency.py` | 新規 | 冪等性検証 |
+
+実装段階で具体ファイル名・分割は微調整可（マイグレーション粒度 5 分割は固定）。既存 `alembic/`・`alembic.ini`・`alembic/env.py` を再初期化（`alembic init`）してはならない。
+
+## 実装方針
+
+1. **Alembic versions の追加**: 既存の `alembic/`・`alembic.ini`・`alembic/env.py` を再初期化せず、`alembic/versions/` 配下に新規リビジョンファイルを追加する。`env.py` は `resolve_database_url()` で `DATABASE_URL` を解決済みのため再実装しない。`target_metadata` は Phase1 では SQLAlchemy ORM を使わず Raw SQL ベースであるため `None` のまま運用する（必要になった段階で `kakeibo.db.models.metadata` を bind する形に拡張）。
+2. **マイグレーション 5 ファイル分割**: 各ファイルに `op.create_table(...)` と `op.create_index(...)` を記述。`down_revision` を明示的に連結し、線形履歴を保つ。
+3. **`amount` NUMERIC**: ADR-005 に従い `sa.Numeric(18, 4)`（整数部 14 桁 + 小数 4 桁）で定義。CHECK 制約で `amount IS NOT NULL` を強制。
+4. **`transactions.hash` UNIQUE**: ADR-006 に従い `CHAR(64)`（SHA256 hex）で定義し `unique=True`。NULL を許容しない。
+5. **`category_source` ENUM**: PostgreSQL ENUM 型として `('rule', 'llm', 'manual')` を作成（`postgresql.ENUM`）。マイグレーションのダウン側で型もドロップ。
+6. **JSONB**: `transactions.raw_payload` は `JSONB` 型（ADR-004）。NULL 可、デフォルト `'{}'::jsonb`。
+7. **冪等性**: Alembic は同じ revision に対し 2 回目の `upgrade head` を no-op として扱うため、1 回目成功後 2 回目を実行してもエラーが出ないことを統合テストで確認する。
+8. **テスト用 Postgres**: ユニットテストでは dev 依存に宣言済みの `testcontainers`（pyproject.toml `[project.optional-dependencies].dev` 参照）でテスト用 Postgres コンテナを立ち上げる、または既存 `tests/_compose_utils.py` ユーティリティ経由で `docker-compose.test.yml` を起動する。テストごとに一時 DB を作成→マイグレーション適用→検証→破棄。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
+
+## 受入条件
+
+- `alembic upgrade head` が空 DB に対して成功する。
+- `alembic upgrade head` を 2 回連続で実行しても 2 回目が no-op として成功する（冪等）。
+- `pytest tests/unit/db/test_schema.py` が以下を緑で検証する。
+  - 7 テーブルすべての存在。
+  - 各テーブルの主要カラム（`amount`, `hash`, `category_source`, `raw_payload` 等）の型と NULL 制約。
+  - `transactions.hash` の UNIQUE インデックス存在。
+  - `category_source` ENUM の許容値が `('rule', 'llm', 'manual')` のみ。
+- `transactions.amount` に文字列・NaN を投入すると、PostgreSQL の型エラーで弾かれる。
+- 同一 `transactions.hash` の 2 回目の INSERT が UNIQUE 違反例外になる。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **スキーマ存在検証**: `information_schema.tables` / `information_schema.columns` を SQL で読み出し、期待スキーマ（テストフィクスチャに JSON で定義）と一致するかを検証する。
+2. **制約違反検証**: NUMERIC への文字列投入、`hash` 重複 INSERT、`category_source` 範囲外値投入が、それぞれ期待される `psycopg.errors.*` 例外を発生させることを確認する。
+3. **冪等性検証**: マイグレーション適用済み DB に対する `alembic upgrade head` 再実行が成功し、テーブル数・行数が変化しないことを確認する。
+
+### 品質ゲート
+
+- ユニットテスト全件 10 秒以内で緑（`agent-rules/11-testing-strategy.md`）。
+- `pyright` 警告ゼロ、`ruff check` 違反ゼロ。
+
+### TDD アプローチ
+
+- Red: マイグレーションを書く前に `test_schema.py` の検証ロジックを書き、期待スキーマと実 DB が一致しないため落ちることを確認。
+- Green: 5 ファイルのマイグレーションを順に追加し、各段階で対応するテストが緑になることを確認。
+- Refactor: マイグレーションヘルパ（共通の ENUM 作成関数等）を抽出。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.1: DBスキーマ・マイグレーション基盤の整備`
+- ブランチ名: `feature/db-schema-initial`
+- ベースブランチ: `develop`
+- マージ戦略: fast-forward（`agent-rules/10-git-strategy.md` 準拠）

--- a/docs/plans/03-phase1-domain-types.md
+++ b/docs/plans/03-phase1-domain-types.md
@@ -1,0 +1,109 @@
+---
+title: Phase 1.2 共通型（Transaction / Holding / BalanceSnapshot）
+phase: 1
+task_id: 1.2
+status: Draft
+priority: 高
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.2 共通型（Transaction / Holding / BalanceSnapshot）
+
+## タスク概要
+
+各取込アダプタが返す**正規化済みドメインオブジェクト**を `dataclass` (or pydantic) でアプリ層に定義し、Phase 1.1 で確立した DB スキーマと型レベルで対応付ける。`compute_hash(account_id, occurred_on, amount, description)` を決定的な SHA256 として実装し、ADR-006 の冪等性戦略をコードで担保する。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.2, `docs/design/01-data-model.md`, `docs/design/02-ingest-adapters.md`。
+
+## 目的・背景
+
+### 目的
+
+- アダプタ層の出力契約を `Transaction` / `Holding` / `BalanceSnapshot` ドメイン型として固定し、Phase 1.3 以降のアダプタ実装が同じ型を返すことで型エラーが検出されるようにする。
+- `Decimal` 型による金額表現（ADR-005）を Python 層で徹底し、`float` 混入を型レベルで防ぐ。
+- ハッシュ生成関数を 1 箇所に集約し、機関ごとのアダプタ実装で再発明されないようにする（ADR-006）。
+
+### 背景
+
+- DB スキーマ（Phase 1.1）が確定しても、アプリ層の型がバラバラだと各アダプタが独自に dict を返してしまい、CLI 永続化層で重複正規化コードが発生する。
+- 共通型は「アダプタの戻り値 → CLI / Watcher の入力」という契約点であり、Phase 2 以降のメールパーサ・API クライアントも同じ型を再利用する。
+- `Decimal` の通貨コード（ISO 4217 3 文字）バリデーションを最初から強制しないと、Phase 4 の集計で「JPY と USD を合算」のような誤りが入り込む余地が残る。
+
+## スコープ
+
+### 含む
+
+- `Transaction` / `Holding` / `BalanceSnapshot` の dataclass（または pydantic v2 モデル）定義。
+- `Transaction.amount` を `Decimal`、`occurred_on` を `date`、`occurred_at` を `Optional[datetime]` として定義。
+- 通貨コードのバリデーション（3 文字英大文字）。
+- `compute_hash(account_id, occurred_on, amount, description) -> str`（SHA256 hex）。
+- 不正値（`amount=None`、通貨コード長違反、`occurred_on` 型違反）でのバリデーションエラー発生。
+- `Holding.symbol_kind` の許容値（`'stock' | 'fund' | 'etf' | 'crypto' | 'cash'` 等、design/01 と整合）の Enum 定義。
+
+### 含まない
+
+- DB との永続化ロジック（CLI / repository は Phase 1.6）。
+- アダプタ実装（Phase 1.3 以降）。
+- LLM / カテゴリ推論の入力としての特殊フィールド（Phase 4.1）。
+
+## 依存タスク
+
+- `02-phase1-db-schema-and-migrations.md`（Phase 1.1）。共通型は DB スキーマと一対一対応で定義するため、スキーマが先に確定している必要がある。
+
+## 後続タスク
+
+- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: `parse(payload) -> Iterable[Transaction]` の戻り値型として参照）。
+- `08-phase1-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性: `compute_hash` の境界条件を property-based test で網羅）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/domain/__init__.py` | パッケージ初期化、公開 API の集約 |
+| `src/kakeibo/domain/transaction.py` | `Transaction` dataclass + `compute_hash` |
+| `src/kakeibo/domain/holding.py` | `Holding` dataclass + `SymbolKind` Enum |
+| `src/kakeibo/domain/balance_snapshot.py` | `BalanceSnapshot` dataclass |
+| `src/kakeibo/domain/currency.py` | 通貨コードバリデータ |
+| `tests/unit/domain/test_transaction.py` | `Transaction` バリデーション + `compute_hash` 決定性 |
+| `tests/unit/domain/test_holding.py` | `Holding` バリデーション + `SymbolKind` 範囲 |
+| `tests/unit/domain/test_balance_snapshot.py` | `BalanceSnapshot` バリデーション |
+
+## 実装方針
+
+1. **dataclass vs pydantic**: 第一選択は `dataclass(frozen=True, slots=True)` + 手書きバリデータ。pydantic を入れると依存が増えるため、Phase1 では避ける。Phase 3（Flask API）で必要になったら導入を検討。
+2. **`Transaction` 必須フィールド**: `account_id: int`, `occurred_on: date`, `occurred_at: Optional[datetime]`, `amount: Decimal`, `currency: str`, `description: str`, `category_id: Optional[int]`, `category_source: Literal['rule','llm','manual'] | None`, `raw_payload: dict[str, Any]`, `hash: str`。
+3. **`__post_init__` でバリデーション**: `amount is None` → `ValueError`、`len(currency) != 3 or not currency.isalpha() or not currency.isupper()` → `ValueError`、`occurred_on` が `date` でない → `TypeError`。
+4. **`compute_hash`**: `f"{account_id}|{occurred_on.isoformat()}|{amount}|{description}"` を UTF-8 エンコードして `hashlib.sha256(...).hexdigest()` を返す。区切り文字 `|` で衝突を低減。description の正規化（前後空白の扱い）は ADR-006 と整合させ、Phase 1.7 の境界条件テストで詳細を確定する（ここではトリミング**しない**を初期方針とする）。
+5. **`SymbolKind`**: `enum.StrEnum` で定義し、`Holding.symbol_kind` は型ヒントを `SymbolKind` に固定。
+6. **`BalanceSnapshot`**: `account_id`, `as_of_date: date`, `balance: Decimal`, `currency: str`。同日同口座の重複は DB 側 UNIQUE で防ぐ。
+
+## 受入条件
+
+- `Transaction.amount` が `Decimal` 型である（`isinstance(tx.amount, Decimal) is True`）。
+- `Transaction.occurred_on` が `date`、`occurred_at` が `Optional[datetime]` である。
+- `amount=None` / 通貨コード `"JP"` / 通貨コード `"jpy"` / `occurred_on=None` のいずれかでインスタンス化すると `ValueError` または `TypeError` が発生する。
+- `compute_hash(1, date(2026,4,30), Decimal("1234.56"), "コンビニ")` が複数回呼んでも同じ SHA256 hex 文字列を返す（決定性）。
+- `Holding.symbol_kind` に `SymbolKind` 以外の値を渡すと型エラー（pyright）または実行時エラー。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **`Transaction` バリデーション**: 正常系 / 異常系の表駆動テスト。`amount=None`, `currency="JP"`, `currency="jpy"`, `currency="JPYY"`, `occurred_on="2026-04-30"`（文字列）など 8 件以上。
+2. **`compute_hash` 決定性**: 同一引数で 100 回呼んでも同じ hex 値。引数 1 つでも変わると別の hex（`account_id`, `occurred_on`, `amount`, `description` を 1 件ずつ変える）。
+3. **`Holding` `SymbolKind`**: 列挙値ごとに正常生成、未定義値で例外。
+4. **`BalanceSnapshot`**: `balance` の `Decimal` 型強制、`as_of_date` の `date` 型強制。
+
+### TDD アプローチ
+
+- Red: ドメイン型ファイルを空のまま、テストファイルを先に書いて落とす。
+- Green: dataclass を最小限で定義し、テストを 1 件ずつ通す。
+- Refactor: バリデーションロジックを `currency.py` 等に抽出して重複を解消。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.2: 共通ドメイン型（Transaction / Holding / BalanceSnapshot）の定義`
+- ブランチ名: `feature/domain-types`
+- ベースブランチ: `develop`

--- a/docs/plans/04-phase1-ingest-adapter-base.md
+++ b/docs/plans/04-phase1-ingest-adapter-base.md
@@ -1,0 +1,108 @@
+---
+title: Phase 1.3 IngestAdapter ABC（取込アダプタ抽象基底）
+phase: 1
+task_id: 1.3
+status: Draft
+priority: 高
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.3 IngestAdapter ABC（取込アダプタ抽象基底）
+
+## タスク概要
+
+ADR-007（アダプタパターン）に従い、機関別取込実装の共通契約を定義する **抽象基底クラス `IngestAdapter`** を実装する。Phase 1.4 / 1.5 の MUFG / SMBC CSV アダプタ、および Phase 2 のメールパーサ・PayPal クライアントがすべて本契約を満たす。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.3, `docs/plans/00-initial-design.md` §5.2, `docs/design/02-ingest-adapters.md`。
+
+## 目的・背景
+
+### 目的
+
+- すべてのアダプタが守るインターフェースを 1 箇所に固定する（`parse(payload) -> Iterable[Transaction]`、`extract_holdings(payload) -> Iterable[Holding]`）。
+- アダプタが返す `Transaction` のソース識別子 `source` 属性を強制し、後段のパイプラインで「どの機関由来の取引か」を区別できるようにする。
+- `account_id` の渡し方を **コンストラクタ注入** で確定する。`parse` / `extract_holdings` の引数は `payload` のみとし、アダプタ単位で `account_id` を保持する設計を本タスクで契約として固定する（Phase 1.4 / 1.5 はこれに従う）。
+- ダミーアダプタ（テスト専用）で契約を検証可能にし、後続タスクのテスト工数を削減する。
+
+### 背景
+
+- `01-development-plan.md` §5 のクリティカルパス上で、Phase 1.4 / 1.5 / Phase 2.x のアダプタはすべて本タスクの ABC を継承する。ABC 未確定のままアダプタを書き始めると、機関ごとに独自インターフェースが乱立する。
+- `IngestAdapter` のみ早めに固めれば、MUFG と SMBC を並行作業に分割できる（`01-development-plan.md` §4.1 Phase 1.5 「Phase 1.4 と並行可」）。
+- Phase 2 の `RawMail` 取得（メールパーサ系）も `parse(payload)` 経由で取り込むため、`payload` 型は `bytes | str | dict[str, Any]` のような Union として柔軟性を持たせる。
+
+## スコープ
+
+### 含む
+
+- `IngestAdapter` ABC の定義（`abc.ABC` 継承、`@abstractmethod` 注釈）。
+- `source: str` クラス属性の強制（未設定サブクラスは初期化時にエラー）。
+- `__init__(self, *, account_id: int)` を ABC 側で固定し、`account_id: int` インスタンス属性として保持する契約。
+- `parse(payload) -> Iterable[Transaction]` および `extract_holdings(payload) -> Iterable[Holding]` 抽象メソッド宣言（`account_id` はインスタンス属性経由で参照、`parse` 引数には含めない）。
+- ダミーアダプタ（テスト fixture 専用）の実装と、契約検証用ユニットテスト。
+
+### 含まない
+
+- 実機関アダプタ（MUFG / SMBC）の実装は Phase 1.4 / 1.5。
+- アダプタ → DB 永続化のパイプライン（Phase 1.6）。
+- 認証情報の扱い（Phase 2.3 / 2.7 で個別に整備）。
+
+## 依存タスク
+
+- `03-phase1-domain-types.md`（Phase 1.2）。`Transaction` / `Holding` 型がないと抽象メソッドの戻り値型が書けない。
+
+## 後続タスク
+
+- `05-phase1-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
+- `06-phase1-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
+- Phase 2 系のメール・API アダプタ（本プラン群の対象外、`01-development-plan.md` §4.2 で扱う）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/__init__.py` | パッケージ初期化 |
+| `src/kakeibo/adapters/base.py` | `IngestAdapter` ABC 本体 + `source` 属性検証メタクラス（or `__init_subclass__`） |
+| `tests/unit/adapters/__init__.py` | テストパッケージ初期化 |
+| `tests/unit/adapters/test_base.py` | 契約検証（抽象メソッド未実装サブクラスのインスタンス化失敗、`source` 必須） |
+| `tests/unit/adapters/_dummy_adapter.py` | テスト用ダミーアダプタ |
+
+## 実装方針
+
+1. **`IngestAdapter(abc.ABC)`**: `__init__(self, *, account_id: int)` を非抽象として ABC 側で実装し `self.account_id = account_id` を保持。`parse` と `extract_holdings` を `@abstractmethod` で定義し、引数は `payload` のみ。戻り値型は `Iterable[Transaction]` / `Iterable[Holding]`。`payload` 型は `bytes | str | dict[str, Any]` の Union（メールも CSV も API レスポンスも受け取れる柔軟性）。
+2. **`source` 強制**: `__init_subclass__(cls, **kwargs)` で `cls.source` の存在と非空文字列をチェックし、未設定なら `TypeError` を送出する。クラス属性として `source: ClassVar[str]` を宣言し、サブクラスで必ず上書きさせる。
+3. **`account_id` 注入**: コンストラクタ引数 `account_id` をサブクラス共通で受け取り、`Transaction` 生成時に `self.account_id` を参照する。`parse(payload, account_id=...)` のような可変引数注入や `parse(payload, **context)` 拡張は採用しない（契約の単純化のため）。
+4. **デフォルト実装**: `extract_holdings` は銀行アダプタには無関係なため、デフォルトで空 `Iterable` を返す具体メソッドにする選択肢もあるが、抽象を保ち各サブクラスで `return ()` を明示する方を採用（明示が型安全）。
+5. **エラー型**: パース失敗時はサブクラスが `kakeibo.adapters.errors.AdapterError`（同タスクで定義）を送出する規約とする。型は本タスクで宣言、利用は Phase 1.4 以降。
+6. **ダミーアダプタ**: `tests/unit/adapters/_dummy_adapter.py` に `class DummyAdapter(IngestAdapter)` を実装し、`parse` が固定の `Transaction` リストを返す。`source = "dummy"`、コンストラクタは `DummyAdapter(account_id=...)` で受ける。
+
+## 受入条件
+
+- `IngestAdapter` は `__init__(self, *, account_id: int)` を備え、`parse(payload) -> Iterable[Transaction]` と `extract_holdings(payload) -> Iterable[Holding]` を抽象メソッドとして持つ。
+- `source` 属性が未設定のサブクラスは初期化（クラス定義時）に `TypeError` で弾かれる。
+- `account_id` を渡さずにサブクラスを初期化すると `TypeError`（Python の標準 `__init__` 挙動）で弾かれる。
+- ダミーアダプタが契約を満たし、ユニットテストで `DummyAdapter(account_id=...)` 経由の `parse` / `extract_holdings` が呼べる。
+- 抽象メソッドを実装していないサブクラスのインスタンス化が `TypeError` で失敗する（Python 標準の `abc` 挙動）。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **抽象メソッド未実装の検出**: `IncompleteAdapter(IngestAdapter)` を `parse` のみ実装する形で書き、インスタンス化が `TypeError` で失敗することを `pytest.raises` で確認。
+2. **`source` 属性必須**: `class NoSourceAdapter(IngestAdapter): ...`（`source` 未定義）を試みると `TypeError` が発生（クラス定義時点で）。
+3. **`account_id` 注入必須**: `DummyAdapter()` を `account_id` キーワード引数なしで初期化すると `TypeError` が発生し、`DummyAdapter(account_id=42)` は成功して `instance.account_id == 42` であることを確認。
+4. **ダミーアダプタの正常動作**: `DummyAdapter(account_id=42).parse(b"")` が `Iterable[Transaction]` を返し、要素が `Transaction` 型かつ `account_id == 42` を持つことを検証。
+5. **`extract_holdings` のデフォルト挙動**: ダミーアダプタが `extract_holdings(b"")` を返す（空でも型に従う）。
+
+### TDD アプローチ
+
+- Red: `tests/unit/adapters/test_base.py` を先に書き、`from kakeibo.adapters.base import IngestAdapter` で ImportError を起こす。
+- Green: `IngestAdapter` ABC を最小限で実装、各テストを順に通す。
+- Refactor: `__init_subclass__` 内のバリデーションを別関数に抽出可能なら抽出。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.3: IngestAdapter 抽象基底クラスの導入`
+- ブランチ名: `feature/ingest-adapter-base`
+- ベースブランチ: `develop`

--- a/docs/plans/05-phase1-mufg-csv-adapter.md
+++ b/docs/plans/05-phase1-mufg-csv-adapter.md
@@ -1,0 +1,111 @@
+---
+title: Phase 1.4 MUFG CSV アダプタ
+phase: 1
+task_id: 1.4
+status: Draft
+priority: 中
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.4 MUFG CSV アダプタ
+
+## タスク概要
+
+三菱UFJ銀行（MUFG）の **Shift_JIS CSV** を `Transaction` に正規化する `MufgCsvAdapter` を実装する。`IngestAdapter` 契約（Phase 1.3）に準拠し、ゴールデンマスタテストで決定的な抽出結果を保証する。Phase1 のクリティカルパス上で、Phase 1.6 取込CLI が依存する。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.4, §3.1 完了条件 (b)（冪等性）, `docs/design/02-ingest-adapters.md`, リスク R-08（文字コード固定）。
+
+## 目的・背景
+
+### 目的
+
+- MUFG の CSV を Shift_JIS で読み込み、各行を `Transaction` に変換する。
+- 出金行は `amount` 負、入金行は `amount` 正で生成し、後段の集計で符号を意識せず合算できるようにする。
+- 同じ CSV 行を再パースしてもハッシュが一致し（`compute_hash` 経由）、CLI 段で UNIQUE 違反として冪等に弾かれる前提を作る。
+
+### 背景
+
+- MUFG の出力 CSV は文字コードが Shift_JIS で固定されており（リスク R-08 の暫定方針）、UTF-8 として読むと文字化け → 摘要ベースのハッシュが破綻する。
+- 銀行 API 直結が不可（ADR-002）、スクレイピング不採用（ADR-003）のため、CSV 取込が唯一の取得経路（ADR-001 ハイブリッド方式）。
+- `01-development-plan.md` §4.1 Phase 1.5（SMBC）と並行可能だが、CLI（Phase 1.6）が両方を必要とするため、本タスクと SMBC は同時期に完了する必要がある。
+
+## スコープ
+
+### 含む
+
+- `MufgCsvAdapter(IngestAdapter)` の実装（`source = "mufg"`）。
+- Shift_JIS デコード処理。デコード失敗時の明示的例外。
+- 列マッピング（日付 / 摘要 / 出金額 / 入金額 / 残高 / 取引区分など、MUFG CSV の実フォーマットに合わせる）。
+- 出金額カラム → 負値、入金額カラム → 正値への正規化。
+- ゴールデンマスタテスト用サンプル CSV（`tests/fixtures/mufg/sample.csv` 等、合成データを Shift_JIS で配置）。
+- ハッシュ生成は共通の `compute_hash` を呼び、本アダプタ内で再実装しない。
+
+### 含まない
+
+- DB 永続化（Phase 1.6 取込CLI の責務）。
+- 実 MUFG 口座のスクレイピング・ログイン自動化（ADR-003 で禁止）。
+- SMBC（Phase 1.5）との CSV 共通化リファクタ（差分が固まってから別ブランチで実施）。
+- ファイル監視（Phase 2.1 Watcher）。
+
+## 依存タスク
+
+- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
+
+## 後続タスク
+
+- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/mufg.py` | `MufgCsvAdapter` 実装 |
+| `src/kakeibo/adapters/errors.py` | `EncodingMismatchError`, `ColumnMissingError`（Phase 1.3 で雛形定義済の場合は追記） |
+| `tests/fixtures/mufg/sample.csv` | Shift_JIS のゴールデンマスタ（合成データ） |
+| `tests/fixtures/mufg/expected.json` | 期待される `Transaction` リスト（フィールドのスナップショット） |
+| `tests/fixtures/mufg/broken_encoding.csv` | エラーパス用（UTF-8 として作成） |
+| `tests/unit/adapters/test_mufg.py` | ゴールデンマスタテスト + エラーパステスト |
+
+## 実装方針
+
+1. **`MufgCsvAdapter` クラス**: `IngestAdapter` を継承、`source: ClassVar[str] = "mufg"` を宣言。コンストラクタは ABC 由来の `__init__(self, *, account_id: int)` をそのまま利用し、追加の引数は取らない（`04-phase1-ingest-adapter-base.md` の契約に従う）。`parse(payload: bytes) -> Iterable[Transaction]` を実装し、`account_id` は `self.account_id` から参照する。`extract_holdings` は空のイテラブルを返す。
+2. **デコード**: `payload.decode("shift_jis")` を `try/except UnicodeDecodeError` で囲み、失敗時は `EncodingMismatchError` を送出。chardet 等の自動判定は **使わない**（リスク R-08 の方針）。
+3. **CSV 解析**: `csv.DictReader` で行イテレーション。MUFG の実フォーマットの列名（例: `日付`, `摘要`, `お支払金額`, `お預り金額`, `差引残高`）を定数化。列が欠損していたら `ColumnMissingError`。
+4. **金額正規化**: 出金額カラムが空でない場合 `amount = -Decimal(value.replace(",", ""))`、入金額カラムが空でない場合 `amount = Decimal(value.replace(",", ""))`。両方空 / 両方ある行は不正データとして例外。
+5. **日付**: `datetime.strptime(row["日付"], "%Y/%m/%d").date()`。年が 2 桁表記の場合は別フォーマットを試行（実 CSV を確認後、フィクスチャに反映）。
+6. **`description` 正規化**: 前後の全角・半角空白除去は **行わない**（ADR-006 の境界条件は Phase 1.7 で確定）。摘要をそのまま採用。
+7. **ハッシュ**: `compute_hash(account_id, occurred_on, amount, description)` を呼ぶ。`account_id` は ABC のコンストラクタで注入された `self.account_id` を参照する（`04-phase1-ingest-adapter-base.md` で確定済の契約）。`parse` 引数で `account_id` を受け取る、または `parse(payload, **context)` への拡張は採用しない。CLI（Phase 1.6）は `MufgCsvAdapter(account_id=...)` でインスタンス化してから `parse(payload)` を呼ぶ。
+8. **ゴールデンマスタ**: `tests/fixtures/mufg/sample.csv` に Shift_JIS で 5〜10 行の合成データを置き、`expected.json` と照合。
+
+## 受入条件
+
+- サンプル CSV（Shift_JIS）から既知の N 件（`expected.json` に定義）の `Transaction` が抽出される（フィールド完全一致）。
+- 出金行は `amount` 負、入金行は `amount` 正。
+- `broken_encoding.csv`（UTF-8）を渡すと `EncodingMismatchError` が送出される。
+- 同一 CSV を再パースしても、生成される `Transaction.hash` が前回と一致する（決定性）。
+- 列が欠損している壊れた CSV で `ColumnMissingError` が送出される。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **ゴールデンマスタテスト**: `sample.csv` をパースし、`expected.json` と完全一致を比較（`Transaction` を `dataclasses.asdict` で dict 化、Decimal は文字列で比較）。
+2. **符号正規化**: 出金 / 入金それぞれ専用の最小 CSV（1 行）を渡し、`amount` の符号を確認。
+3. **エンコーディング不一致**: UTF-8 で書いた CSV を渡し、`EncodingMismatchError` を `pytest.raises` で確認。
+4. **列欠損**: 必須列を 1 つ抜いた CSV で `ColumnMissingError`。
+5. **数値パース不能**: 出金額に `"abc"` が入った行で `ValueError`（または専用例外）。
+6. **ハッシュ決定性**: 同じ CSV を 2 回 parse し、生成された `Transaction` リストの `hash` 列が完全一致。
+
+### TDD アプローチ
+
+- Red: `tests/fixtures/mufg/sample.csv` と `expected.json` を作り、`MufgCsvAdapter` 未実装の状態でテストを書いて落とす。
+- Green: 最小実装で 1 件抽出から始め、徐々にゴールデンマスタ全件を通す。
+- Refactor: 列名定数 / 金額正規化ロジックを関数抽出。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.4: MUFG CSV 取込アダプタの実装`
+- ブランチ名: `feature/adapter-mufg-csv`
+- ベースブランチ: `develop`

--- a/docs/plans/06-phase1-smbc-csv-adapter.md
+++ b/docs/plans/06-phase1-smbc-csv-adapter.md
@@ -1,0 +1,103 @@
+---
+title: Phase 1.5 SMBC CSV アダプタ
+phase: 1
+task_id: 1.5
+status: Draft
+priority: 中
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.5 SMBC CSV アダプタ
+
+## タスク概要
+
+三井住友銀行（SMBC）の CSV を `Transaction` に正規化する `SmbcCsvAdapter` を実装する。`IngestAdapter` 契約（Phase 1.3）に準拠し、MUFG アダプタ（Phase 1.4）と独立して動作する。MUFG とは列順・列名・摘要正規化の差分が想定されるため、本タスクで SMBC 固有の振る舞いを切り分ける。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.5, `docs/design/02-ingest-adapters.md`。
+
+## 目的・背景
+
+### 目的
+
+- SMBC の CSV を読み込み、各行を `Transaction` に変換する。
+- MUFG とは別の列順・列名でも、同じ `IngestAdapter` 契約を満たすことを実証する。
+- SMBC 特有の摘要表記（全角スペース・全角記号など）の正規化方針を決定し、ハッシュ生成への影響を最小化する。
+
+### 背景
+
+- 銀行ごとに CSV のフォーマットが大きく異なるため、共通化を急ぐと壊れやすい抽象化になる。各機関ごとに専用アダプタを用意する方針（ADR-007）。
+- SMBC の出力 CSV はエンコーディングが UTF-8 または Shift_JIS のいずれかである可能性があるため、実 CSV を確認して固定する（リスク R-08 と同様の方針：自動判定は使わない）。
+- Phase 1.4（MUFG）と並行作業可能（`01-development-plan.md` §4.1 Phase 1.5 の依存欄）。CLI（Phase 1.6）が両方を呼ぶため、両アダプタが揃った段階で次に進む。
+
+## スコープ
+
+### 含む
+
+- `SmbcCsvAdapter(IngestAdapter)` の実装（`source = "smbc"`）。
+- SMBC 固有の列順・列名へのマッピング（実フォーマットを fixtures に固定）。
+- 摘要の全角スペース除去等の SMBC 固有正規化（必要なら）。
+- ゴールデンマスタテスト用サンプル CSV と期待結果。
+
+### 含まない
+
+- MUFG アダプタ（Phase 1.4）と SMBC アダプタの抽象化リファクタ。Phase 1 の段階では別実装で十分（早すぎる抽象化を避ける）。
+- DB 永続化（Phase 1.6）。
+- ファイル監視・ディレクトリ振り分け（Phase 2.1 / 2.2）。
+
+## 依存タスク
+
+- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
+- `05-phase1-mufg-csv-adapter.md`（Phase 1.4）とは独立で並行可能だが、参考実装として参照する。
+
+## 後続タスク
+
+- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/smbc.py` | `SmbcCsvAdapter` 実装 |
+| `tests/fixtures/smbc/sample.csv` | SMBC ゴールデンマスタ（合成データ） |
+| `tests/fixtures/smbc/expected.json` | 期待される `Transaction` リスト |
+| `tests/unit/adapters/test_smbc.py` | ゴールデンマスタ + 列差分検証 + 摘要正規化テスト |
+
+## 実装方針
+
+1. **`SmbcCsvAdapter` クラス**: `IngestAdapter` を継承、`source: ClassVar[str] = "smbc"`。`parse(payload: bytes) -> Iterable[Transaction]`。
+2. **列マッピング**: SMBC の列名（例: `年月日`, `お引出し`, `お預入れ`, `お取り扱い内容`, `残高`）を定数化。MUFG とは別の列名であることを明示する。
+3. **摘要正規化**: 全角スペース → 半角スペース or 削除、全角ハイフン → 半角ハイフン等の正規化を `_normalize_description(s: str) -> str` として実装。Phase 1.7 のハッシュ境界条件テストと整合させる。
+4. **金額符号**: MUFG と同様、お引出し → 負、お預入れ → 正。
+5. **ハッシュ生成**: 共通 `compute_hash` を呼ぶ。`account_id` の渡し方は MUFG と同じ方式を採用（Phase 1.4 で決定した方式に揃える）。
+6. **MUFG との差分明示**: テスト内で「MUFG の `expected.json` を SMBC アダプタに渡しても抽出できない」等の独立性チェックを 1 件入れる（列名が異なるため失敗する）。
+
+## 受入条件
+
+- サンプル CSV から `expected.json` に定義された既知の N 件が抽出される。
+- MUFG アダプタとは独立して `IngestAdapter` 契約を満たす（`source = "smbc"`、抽象メソッドが実装済み）。
+- 列順・列名差分が MUFG と区別される（MUFG の sample.csv を本アダプタに渡すと `ColumnMissingError`）。
+- SMBC 特有の摘要正規化が適用された結果でハッシュが決定的に同一になる。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **ゴールデンマスタテスト**: `sample.csv` → `expected.json` 完全一致。
+2. **MUFG 入力での失敗確認**: MUFG の sample を SMBC アダプタに渡して `ColumnMissingError` 発生（独立性の証明）。
+3. **摘要正規化**: 全角スペースありの摘要 / なしの摘要が同一の正規化済み文字列になることを確認（`_normalize_description` の単体テスト）。
+4. **金額符号**: 引出 / 預入それぞれの最小ケース。
+5. **ハッシュ決定性**: 同一 CSV の 2 回パースで `Transaction.hash` 一致。
+
+### TDD アプローチ
+
+- Red: `tests/fixtures/smbc/sample.csv` と `expected.json` を作り、`SmbcCsvAdapter` 未実装でテストを落とす。
+- Green: 最小実装からゴールデンマスタ全件を通す。
+- Refactor: 共通になりそうな部分は anti-pattern を避けて意図的に重複を残し、Phase 2 以降で必要が確定してから抽出。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.5: SMBC CSV 取込アダプタの実装`
+- ブランチ名: `feature/adapter-smbc-csv`
+- ベースブランチ: `develop`

--- a/docs/plans/07-phase1-ingest-cli.md
+++ b/docs/plans/07-phase1-ingest-cli.md
@@ -1,0 +1,115 @@
+---
+title: Phase 1.6 取込CLI
+phase: 1
+task_id: 1.6
+status: Draft
+priority: 高
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.6 取込CLI
+
+## タスク概要
+
+`python -m kakeibo.ingest <institution> <path>` 相当のコマンドを提供し、**アダプタ起動 → DB 永続化 → 原本退避**までを一気通貫で実行する CLI を実装する。Phase1 完了条件 (b)「同一 CSV を 2 回投入しても `transactions` 行数が増えない」を直接満たす。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.6, §3.1 完了条件 (b), `docs/design/02-ingest-adapters.md`, `docs/design/08-ingest-flow.md`。
+
+## 目的・背景
+
+### 目的
+
+- 機関コードとファイルパスを引数に取り、対応するアダプタを起動して `Transaction` を抽出し、DB に永続化する。
+- `transactions.hash` の UNIQUE 制約を活用して、同じファイルを再投入しても行数が増えない冪等性を実現する（ADR-006）。
+- `--dry-run` で DB に書き込まずに抽出結果のみ表示できるようにし、運用での確認用途を支える。
+- 終了コードを成功 0 / 失敗 非0 で正しく返し、Phase 2.1 の Watcher サービスからスクリプト経由で起動できるようにする。
+
+### 背景
+
+- Phase1 完了条件のうち (b) と、間接的に (c)（月次サマリ SQL の前提となるデータ投入）を本タスクで満たす。
+- Phase 2.1 の Watcher は CLI を `subprocess` 経由で呼ぶ前提のため、CLI が安定した終了コード規約を持つことが必須。
+- 機関コード判定は CLI 引数で行い、Watcher 段階ではディレクトリ名から自動判定する（責務を分離）。
+
+## スコープ
+
+### 含む
+
+- CLI エントリポイント `src/kakeibo/ingest/cli.py`。`click` または `argparse` ベース。
+- 機関コード → アダプタクラスのレジストリ（`{"mufg": MufgCsvAdapter, "smbc": SmbcCsvAdapter}`）。
+- DB へのバルク INSERT（`INSERT ... ON CONFLICT (hash) DO NOTHING` で冪等化）。
+- `--dry-run` オプション（DB 書き込みをスキップし、抽出件数 + サンプル数件を標準出力）。
+- 終了コード規約（成功 = 0、引数不正 = 2、パース失敗 = 3、DB エラー = 4）。
+- 取込結果のサマリログ（取込件数 / 重複でスキップした件数）。
+
+### 含まない
+
+- ファイル監視（Phase 2.1）。
+- 取込済みファイルの自動アーカイブ移動（Phase 2.2）。
+- メール / API 取込（Phase 2.3〜2.7）。
+- Web UI 経由の取込（Phase 3）。
+
+## 依存タスク
+
+- `05-phase1-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
+- `06-phase1-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
+
+## 後続タスク
+
+- `08-phase1-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性ユニットテスト強化）。
+- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 本 CLI で投入したデータを集計）。
+- Phase 2.1 Watcher（本プラン群の対象外、`01-development-plan.md` §4.2 で扱う）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/ingest/__init__.py` | パッケージ初期化 |
+| `src/kakeibo/ingest/cli.py` | CLI エントリ。`if __name__ == "__main__": ...` を含む |
+| `src/kakeibo/ingest/registry.py` | 機関 → アダプタクラスのレジストリ |
+| `src/kakeibo/ingest/persister.py` | DB 永続化（`ON CONFLICT (hash) DO NOTHING`） |
+| `tests/unit/ingest/test_cli.py` | CLI 引数 / 終了コード / dry-run テスト |
+| `tests/unit/ingest/test_persister.py` | 冪等 INSERT 検証（実 Postgres or テスト用 DB） |
+
+## 実装方針
+
+1. **CLI フレームワーク**: `click` を採用（テスタビリティが高く、`CliRunner` で in-process 実行可能）。`pyproject.toml` の依存に追加。
+2. **コマンドシグネチャ**: `kakeibo.ingest <institution> <path> [--dry-run] [--account-id INT]`。`--account-id` は CSV に口座 ID が含まれない場合の指定用（Phase1 では機関＋口座が 1:1 を仮定）。
+3. **アダプタ呼び出し**: `registry.get(institution)` でアダプタクラスを取得 → インスタンス化 → `parse(file_bytes)` で `Iterable[Transaction]` を取得。
+4. **DB 永続化**: SQLAlchemy Core の `insert(...).on_conflict_do_nothing(index_elements=["hash"])` で一括 INSERT。トランザクション境界はコマンド全体で 1 つ。
+5. **dry-run**: `--dry-run` 指定時は `persister.persist(...)` をスキップし、`len(transactions)` と先頭 3 件を `print` する。
+6. **終了コード**: `click` の例外ハンドリングで `EncodingMismatchError` / `ColumnMissingError` → exit 3、`psycopg.Error` → exit 4、その他 `SystemExit(2)` は引数不正。
+7. **ログ**: `logging.getLogger("kakeibo.ingest")` を使用し、構造化ログ（INFO で件数、WARNING で重複スキップ件数）。
+8. **テストでの DB**: dev 依存に宣言済みの `testcontainers`（pyproject.toml `[project.optional-dependencies].dev`）または既存 `tests/_compose_utils.py` を活用し、テストごとに一時 DB を立ち上げて Phase 1.1 のマイグレーションを適用。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
+
+## 受入条件
+
+- CLI で MUFG / SMBC の CSV を取り込み、`transactions` 行数が増える。
+- 同じファイルを 2 回投入しても、2 回目で行数が増えない（`ON CONFLICT DO NOTHING` 確認）。
+- 終了コードが成功時 0、CSV パース失敗時 3、DB エラー時 4。
+- `--dry-run` 指定時に DB に書き込まれず、件数とサンプルが標準出力に表示される。
+- 未対応の機関コード（例: `paypal`）を渡すと exit 2 と適切なエラーメッセージ。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **正常系**: `CliRunner().invoke(cli, ["mufg", str(fixture_path)])` で exit 0、DB 行数が期待と一致。
+2. **冪等性**: 同じファイルを 2 回 invoke、2 回目の DB 行数が変化しない。
+3. **dry-run**: `--dry-run` 指定で DB に書き込まれない（行数 0 のまま）、stdout に件数表示。
+4. **エラーパス**: 壊れた CSV → exit 3、未対応機関 → exit 2。
+5. **registry**: `registry.get("mufg")` が `MufgCsvAdapter`、`registry.get("nonexistent")` が `KeyError`。
+6. **永続化単体**: `persister.persist(transactions)` を直接呼び、`ON CONFLICT DO NOTHING` の動作を SQL レベルで確認。
+
+### TDD アプローチ
+
+- Red: `tests/unit/ingest/test_cli.py` で `CliRunner` ベースのテストを書き、CLI 未実装で落とす。
+- Green: `cli.py` を最小実装（成功パスのみ）→ 冪等性 → エラーパスの順に実装。
+- Refactor: 永続化ロジックを `persister.py` に切り出し、CLI は引数解釈に専念。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.6: 取込CLI（アダプタ起動 → DB 永続化）の実装`
+- ブランチ名: `feature/ingest-cli`
+- ベースブランチ: `develop`

--- a/docs/plans/08-phase1-hash-idempotency-tests.md
+++ b/docs/plans/08-phase1-hash-idempotency-tests.md
@@ -1,0 +1,120 @@
+---
+title: Phase 1.7 ハッシュ冪等性ユニットテスト強化
+phase: 1
+task_id: 1.7
+status: Draft
+priority: 中
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.7 ハッシュ冪等性ユニットテスト強化
+
+## タスク概要
+
+`compute_hash` の **境界条件**を property-based test（hypothesis）で網羅し、ハッシュ衝突・誤マージ・冪等性破綻を検出する。Phase1 完了条件 (b) の保険として機能し、Phase 1.6 取込CLI の冪等性を「同じファイル 2 回投入で行数増えず」よりさらに細かい粒度で保証する。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.7, `docs/adr/006-hash-uniqueness.md`, `docs/design/01-data-model.md`。
+
+## 目的・背景
+
+### 目的
+
+- 同一 `(account_id, occurred_on, amount, description)` から生成されるハッシュが常に一致することを多様な入力で確認する。
+- 通貨違いや口座違いで必ず別ハッシュになることを property-based test で検証する。
+- description の前後空白差異の扱いについて方針を確定し、テストで固定する（正規化するか、しないか）。
+- 100 件規模のサンプルでハッシュ衝突がゼロであることを確認する。
+
+### 背景
+
+- ADR-006 のハッシュ戦略は Phase 1.2 で `compute_hash` として実装されているが、ユニットテストでは決定性の確認のみで境界条件が網羅されていない。
+- Phase 1.6 取込CLI の段階で「同じ CSV 2 回投入」レベルの冪等性は確認されるが、CSV を跨いだ同日同額の別取引（実運用で発生）の扱いは未検証。
+- 半角・全角空白、改行コード、Unicode 結合文字（NFC / NFD）など、文字コード境界での衝突が後から判明すると、運用初期に二重計上が起きるリスクがある。
+
+## スコープ
+
+### 含む
+
+- hypothesis を導入し、`compute_hash` への入力をランダム生成して以下を検証：
+  - 同一入力 → 同一ハッシュ（決定性）。
+  - 1 引数違い → 別ハッシュ（衝突確率がほぼゼロ）。
+  - 100 件規模のランダム入力で衝突 0。
+- description の前後空白差異の扱いを ADR-006 と整合する形で決定し、テストで固定する。
+- 通貨違いの場合のハッシュ差異を検証（**現行設計では `compute_hash` の引数に `currency` は含まれていない** ため、`currency` を含めるか、別レイヤーで区別するかをこのタスクで明確化する。設計判断が必要なら ADR-006 改訂を起票し、`docs/plans/01-development-plan.md` §10.3 のアンチパターンに従って本プランで勝手に変更しない）。
+
+### 含まない
+
+- DB 制約の検証（Phase 1.1 で実施済）。
+- アダプタ単体での冪等性確認（Phase 1.4 / 1.5 のゴールデンマスタテストで実施済）。
+- DB を含む統合テスト（Phase 1.6 で実施済）。
+- LLM 分類のハッシュへの影響（Phase 4.1 の責務）。
+
+## 依存タスク
+
+- `03-phase1-domain-types.md`（Phase 1.2 共通型: `compute_hash` の実装が前提）。
+- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 実運用の入力データを参考に境界条件を抽出）。
+
+## 後続タスク
+
+- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 冪等性が保証されてから集計の正確性を検証）。
+- Phase 4.4 残高整合性レポート（本プラン群の対象外）が冪等性の保険を活用する。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `tests/unit/domain/test_hash.py` | property-based test 本体（hypothesis 利用） |
+| `tests/unit/domain/test_hash_boundary.py` | 境界条件の表駆動テスト（半角・全角空白、Unicode 正規化等） |
+| `pyproject.toml` | 既存・参照のみ。hypothesis は `[project.optional-dependencies].dev` に `"hypothesis>=6.100,<7"` として既に宣言済みのため変更不要（`[tool.uv.dev-dependencies]` セクションは存在しない） |
+| `src/kakeibo/domain/transaction.py` | `compute_hash` 本体（Phase 1.2 で実装済）。本タスクで判明した境界条件に応じて正規化方針を反映する場合のみ変更 |
+
+## 実装方針
+
+1. **hypothesis 戦略の構築**:
+   - `account_id`: `st.integers(min_value=1, max_value=10**6)`。
+   - `occurred_on`: `st.dates(min_value=date(2000,1,1), max_value=date(2100,12,31))`。
+   - `amount`: `st.decimals(min_value=Decimal("-1e9"), max_value=Decimal("1e9"), places=4, allow_nan=False, allow_infinity=False)`。
+   - `description`: `st.text(min_size=0, max_size=200)`。
+2. **決定性テスト**: `@given(...)` で入力を生成し、`compute_hash(...) == compute_hash(...)` を毎回確認。
+3. **1 引数違いテスト**: `@given(...)` で入力を生成し、4 つの引数のうち 1 つだけを変更すると別ハッシュになることを確認。`account_id` を `+1` した場合などをチェック。
+4. **大量サンプル衝突ゼロ**: 100 件のランダム入力をセットで生成し、生成されたハッシュ集合のサイズが 100 であること（衝突なし）を確認。
+5. **境界条件の表駆動テスト**:
+   - description の前後半角空白差異 → 別ハッシュ（正規化しない方針を初期採用、ADR-006 と整合）。
+   - 全角空白と半角空白 → 別ハッシュ。
+   - 改行コード（\\r\\n vs \\n） → 別ハッシュ。
+   - Unicode NFC / NFD → 別ハッシュ（NFC 正規化を後で導入する場合は ADR-006 改訂と本テスト改修を同時に行う）。
+6. **通貨の扱い**: 現行 `compute_hash` シグネチャに `currency` がないため、テスト内で「同 description / 異 currency の取引が同ハッシュになる」ことを **問題として明示**するテストを 1 件記述し、Phase 1 の暫定方針として「機関ごとに通貨は固定なので account_id で区別される」ことをコメントで残す（ADR-006 の改訂は別タスク）。
+
+## 受入条件
+
+- 同一 `(account_id, occurred_on, amount, description)` は同一ハッシュ（hypothesis で 100 例以上検証）。
+- description の前後空白差異で異なるハッシュ（または明示的に正規化される。本プラン執筆時点では「正規化しない」が初期方針）。
+- 通貨が異なる取引で同ハッシュとなる現状を **テストで明示**し、設計上の前提（account_id で区別）をコメントで残す。
+- 100 件のランダムサンプルでハッシュ衝突が 0 件。
+- 1 引数違いの入力ペアが 100 例とも別ハッシュ。
+- `pyright` クリーン、`ruff` 違反なし、テストが 10 秒以内で完了。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **`test_hash.py`**: hypothesis ベースの property-based test。決定性 + 1 引数違いでの分離 + 衝突ゼロ。
+2. **`test_hash_boundary.py`**: 表駆動テストで以下を検証。
+   - 半角空白前後差異（"foo" vs " foo "）。
+   - 全角空白を含む（"foo　bar" vs "foo bar"）。
+   - 改行コード差異。
+   - Unicode 結合文字（"が" vs "か" + 濁点）。
+   - 空文字 description の扱い。
+3. **`test_hash.py` の通貨注記**: 同入力で `currency` だけが違うケースは現行 API では区別されないことを `pytest.mark.xfail` または `assert ==` で明示し、コメントで設計意図を残す。
+
+### TDD アプローチ
+
+- Red: hypothesis 未導入かつ境界テストが書かれていない状態で、新規テストファイルを作成。
+- Green: hypothesis を依存に追加し、テストを通す。`compute_hash` の挙動を変更しない（Phase 1.2 で確定済を尊重）。
+- Refactor: テストデータ生成ヘルパを抽出。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.7: ハッシュ冪等性ユニットテストの強化（hypothesis 導入）`
+- ブランチ名: `feature/hash-idempotency-tests`
+- ベースブランチ: `develop`

--- a/docs/plans/09-phase1-monthly-summary-sql.md
+++ b/docs/plans/09-phase1-monthly-summary-sql.md
@@ -1,0 +1,122 @@
+---
+title: Phase 1.8 月次サマリ SQL
+phase: 1
+task_id: 1.8
+status: Draft
+priority: 中
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase 1.8 月次サマリ SQL
+
+## タスク概要
+
+Phase1 完了条件 (c)「SQL で月次サマリが手計算と一致」を満たす集計クエリを `sql/queries/monthly_summary.sql` として配置する。サンプルデータを投入してテストから呼び出し、Excel 等での手計算結果と完全一致することを保証する。
+
+参照: `docs/plans/01-development-plan.md` §4.1 Phase 1.8, §3.1 完了条件 (c), `docs/design/01-data-model.md`。
+
+## 目的・背景
+
+### 目的
+
+- 月別・カテゴリ別に集計した支出 / 収入額を返す SQL を `sql/queries/monthly_summary.sql` に配置する。
+- カテゴリ未分類の取引も「その他」として集計から漏れないようにする。
+- pytest からクエリを実行して、固定フィクスチャと期待 DataFrame を比較できる仕組みを作る。
+
+### 背景
+
+- Phase1 完了条件 (c) を直接満たすタスクであり、Phase1 全体の「動作する MVP」を最後に検証する位置付け。
+- Phase 3.3 の月次推移グラフ、Phase 4.5 の Obsidian 月次サマリ出力でも本クエリ（または派生）を再利用するため、SQL ファイルとして独立配置することで再利用性を担保する。
+- アプリ層から呼び出すか、`psql -f` で実行するかの選択肢があるが、Phase 3 で REST API から呼び出す前提で、Python 側にラッパー関数を用意する。
+
+## スコープ
+
+### 含む
+
+- `sql/queries/monthly_summary.sql`（純 SQL ファイル、引数 `:year_month` などを `psycopg` 経由で展開）。
+- 月別 × カテゴリ別の合計金額、取引件数、収入 / 支出別の小計。
+- カテゴリ未分類取引の `その他` 列（または `category_id IS NULL` のグループ）への集計。
+- pytest からクエリを実行するヘルパ（例: `kakeibo.sql.run_query("monthly_summary.sql", year_month=...)`）。
+- 固定フィクスチャ（手計算可能な少量データ）と期待結果 DataFrame の比較テスト。
+
+### 含まない
+
+- 残高推移（Phase 3.3 / Phase 4.4 で別クエリを作成）。
+- カテゴリ階層のロールアップ（親カテゴリへの集計、Phase 3.4 で扱う）。
+- UI 表示用フォーマット（Phase 3 の責務）。
+- インデックス最適化（実データ規模で問題が出てから対応）。
+
+## 依存タスク
+
+- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 集計対象となる `transactions` レコードを生成する手段）。
+
+## 後続タスク
+
+- Phase 3.3 月次推移グラフ（本プラン群の対象外、`01-development-plan.md` §4.3 で扱う）。
+- Phase 4.4 残高整合性レポート（本プラン群の対象外）。
+- Phase 4.5 Obsidian 月次サマリ出力（本プラン群の対象外）。
+
+## 対象ファイル/モジュール
+
+| パス | 役割 |
+|---|---|
+| `sql/queries/monthly_summary.sql` | 月次サマリ SQL 本体 |
+| `src/kakeibo/sql/__init__.py` | SQL ファイル読込ヘルパ |
+| `src/kakeibo/sql/runner.py` | `run_query(filename, **params)` の実装 |
+| `tests/fixtures/sql/monthly_summary_seed.sql` | テスト用フィクスチャ（小量サンプル取引） |
+| `tests/fixtures/sql/monthly_summary_expected.json` | 期待される集計結果 |
+| `tests/unit/sql/test_monthly_summary.py` | クエリ実行 + 期待結果比較 |
+
+## 実装方針
+
+1. **SQL 構造**:
+   ```sql
+   SELECT
+       date_trunc('month', occurred_on)::date AS month,
+       COALESCE(c.name, 'その他') AS category_name,
+       SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END) AS expense,
+       SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) AS income,
+       COUNT(*) AS tx_count
+   FROM transactions t
+   LEFT JOIN categories c ON c.id = t.category_id
+   WHERE occurred_on >= :date_from AND occurred_on < :date_to
+   GROUP BY 1, 2
+   ORDER BY 1, 2;
+   ```
+2. **パラメータ**: `:date_from`, `:date_to`（両端の含む / 含まないを境界として明確化、`[from, to)` 半開区間）。
+3. **未分類取引**: `LEFT JOIN` + `COALESCE(c.name, 'その他')` で取りこぼしを防ぐ。
+4. **金額の符号**: 出金は負値で格納されているため、`-t.amount` で正の支出額に戻す。
+5. **runner ヘルパ**: `pathlib.Path(__file__).parent.parent.parent / "sql" / "queries" / filename` で SQL を読み込み、`psycopg.cursor.execute(sql, params)` で実行。`params` は `dict[str, Any]`、SQL 内では `%(date_from)s` 形式で展開（psycopg 規約）。あるいは `:name` 形式の場合は SQLAlchemy の `text()` を使う。
+6. **テストフィクスチャ**: `monthly_summary_seed.sql` で `institutions` / `accounts` / `categories` / `transactions` を 5〜10 件投入。期待結果は `expected.json` に手計算で記載。
+7. **比較**: `pytest` 内でクエリ結果（`list[dict]`）と `expected.json` を `Decimal` 精度で比較。`json.loads` 時は `parse_float=Decimal` で読み込む。
+
+## 受入条件
+
+- サンプルデータ投入後、`monthly_summary.sql` の出力が手計算（`expected.json`）と完全一致する（Decimal 精度で比較）。
+- カテゴリ未分類の取引（`category_id IS NULL`）も `その他` として集計に含まれる。
+- pytest からクエリを呼び出して値を検証できる（テストが緑）。
+- 期間境界（月初 0:00 / 翌月 1 日 0:00）が `[from, to)` 半開区間として正しく扱われる。
+- `pyright` クリーン、`ruff` 違反なし。
+
+## テスト計画
+
+### ユニットテスト（テスト先行）
+
+1. **基本集計**: 5〜10 件のサンプル取引を投入し、月別 × カテゴリ別の集計が `expected.json` と一致。
+2. **未分類取引**: `category_id = NULL` の取引が `その他` カテゴリに集計される。
+3. **期間境界**: 月末 23:59 と翌月 0:00 の取引が、それぞれ正しい月にカウントされる。
+4. **空期間**: 取引のない期間を渡すと空リスト（または件数 0 行）が返る。
+5. **複数月**: 2 か月にまたがるデータで、月ごとに正しく分割される。
+
+### TDD アプローチ
+
+- Red: フィクスチャ + `expected.json` を準備し、`runner.run_query("monthly_summary.sql", ...)` 未実装でテストを落とす。
+- Green: `runner.py` と SQL を最小実装して 1 件目のテストを通す → 順次他のケースを通す。
+- Refactor: SQL を CTE で読みやすくする / runner のキャッシュ機構を入れる。
+
+## 想定 issue タイトル / ブランチ名
+
+- 想定 issue タイトル: `Phase 1.8: 月次サマリ SQL の実装と手計算一致検証`
+- ブランチ名: `feature/monthly-summary-sql`
+- ベースブランチ: `develop`

--- a/docs/plans/10-phase1-overview.md
+++ b/docs/plans/10-phase1-overview.md
@@ -1,0 +1,149 @@
+---
+title: Phase1 タスクプラン全体俯瞰インデックス
+phase: 1
+status: Draft
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-04-30
+---
+
+# Phase1 タスクプラン全体俯瞰インデックス
+
+`docs/plans/01-development-plan.md` §4.1 Phase 1（タスク 1.1〜1.8）を、1 issue / 1 ブランチ / 1 PR 単位で着手できる **8 本のタスクプラン**に分解した目次である。本ファイルは Phase1 全体の到達目標・タスク一覧・実装順序・依存関係を一望し、各プランファイルへ確実に到達できるようにすることを目的とする。
+
+## 1. Phase1 全体ゴール
+
+`docs/plans/01-development-plan.md` §3.1 から要約。
+
+> **MVP**: MUFG / SMBC の CSV を CLI から取込み、PostgreSQL に正規化済み取引が格納される。SQL で月次サマリが手計算と一致する。
+
+### 完了条件（同 §3.1）
+
+| ID | 条件 | 担当タスク（プランファイル） |
+|---|---|---|
+| (a) | `alembic upgrade head` が冪等に実行できる | `02-phase1-db-schema-and-migrations.md` |
+| (b) | 同一 CSV を 2 回投入しても `transactions` 行数が増えない | `07-phase1-ingest-cli.md` + `08-phase1-hash-idempotency-tests.md` |
+| (c) | サンプル CSV から月次合計を集計する SQL が手計算結果と一致する | `09-phase1-monthly-summary-sql.md` |
+| (d) | 全ユニットテストが緑、`pyright` クリーン | 全プラン横断（各プランの「テスト計画」「受入条件」に明記） |
+
+### 関連設計資産
+
+- ADR: ADR-001 / 002 / 004 / 005 / 006 / 007
+- design: `design/01-data-model.md`, `design/02-ingest-adapters.md`, `design/08-ingest-flow.md`
+
+## 2. タスク一覧表
+
+| 連番 | タスクID | タイトル | プランファイル | ブランチ名 | 依存タスク | 優先度 |
+|---|---|---|---|---|---|---|
+| 02 | 1.1 | DBスキーマ・マイグレーション基盤 | `02-phase1-db-schema-and-migrations.md` | `feature/db-schema-initial` | なし | 高 |
+| 03 | 1.2 | 共通型（Transaction / Holding / BalanceSnapshot） | `03-phase1-domain-types.md` | `feature/domain-types` | `02-phase1-db-schema-and-migrations.md` | 高 |
+| 04 | 1.3 | IngestAdapter ABC | `04-phase1-ingest-adapter-base.md` | `feature/ingest-adapter-base` | `03-phase1-domain-types.md` | 高 |
+| 05 | 1.4 | MUFG CSV アダプタ | `05-phase1-mufg-csv-adapter.md` | `feature/adapter-mufg-csv` | `04-phase1-ingest-adapter-base.md` | 中 |
+| 06 | 1.5 | SMBC CSV アダプタ | `06-phase1-smbc-csv-adapter.md` | `feature/adapter-smbc-csv` | `04-phase1-ingest-adapter-base.md` | 中 |
+| 07 | 1.6 | 取込CLI | `07-phase1-ingest-cli.md` | `feature/ingest-cli` | `05-phase1-mufg-csv-adapter.md`, `06-phase1-smbc-csv-adapter.md` | 高 |
+| 08 | 1.7 | ハッシュ冪等性ユニットテスト強化 | `08-phase1-hash-idempotency-tests.md` | `feature/hash-idempotency-tests` | `03-phase1-domain-types.md`, `07-phase1-ingest-cli.md` | 中 |
+| 09 | 1.8 | 月次サマリ SQL | `09-phase1-monthly-summary-sql.md` | `feature/monthly-summary-sql` | `07-phase1-ingest-cli.md` | 中 |
+
+### 優先度の付与基準
+
+- **高**: 後続タスクをブロックする上流（クリティカルパス上）。1.1 / 1.2 / 1.3 / 1.6。
+- **中**: 並行可能だが Phase1 完了に必須。1.4 / 1.5 / 1.7 / 1.8。
+- **低**: Phase1 では発生しない（全タスクが完了条件に必須のため、自然発生する低優先タスクが存在しない）。
+
+## 3. 実装順序
+
+依存関係を考慮した推奨実装順序を示す。1.4 と 1.5 のように「依存が同じで相互独立」なタスクは並行可能。
+
+### 直列の上流（1 → 2 → 3 の順で完了させる）
+
+1. `02-phase1-db-schema-and-migrations.md`（DBスキーマ）
+2. `03-phase1-domain-types.md`（共通型）
+3. `04-phase1-ingest-adapter-base.md`（IngestAdapter ABC）
+
+### 並行可能なアダプタ層
+
+4a. `05-phase1-mufg-csv-adapter.md`（MUFG）
+4b. `06-phase1-smbc-csv-adapter.md`（SMBC）
+
+両方の完了を待ってから次へ進む。
+
+### 統合と検証
+
+5. `07-phase1-ingest-cli.md`（取込CLI、4a / 4b の合流点）
+6a. `08-phase1-hash-idempotency-tests.md`（ハッシュ冪等性）
+6b. `09-phase1-monthly-summary-sql.md`（月次サマリ SQL）
+
+6a と 6b は CLI 完了後に並行可能。両方完了で Phase1 完了条件 (a)〜(d) が揃う。
+
+### 推奨直列順（1 人で実装する場合）
+
+`02 → 03 → 04 → 05 → 06 → 07 → 08 → 09`
+
+## 4. 依存関係図
+
+`docs/plans/01-development-plan.md` §5 の Phase1 部分を、本プラン群のファイル名で表現したもの。
+
+```mermaid
+flowchart TD
+    P02["02 DBスキーマ<br/>(1.1)"]
+    P03["03 共通型<br/>(1.2)"]
+    P04["04 IngestAdapter ABC<br/>(1.3)"]
+    P05["05 MUFG CSV<br/>(1.4)"]
+    P06["06 SMBC CSV<br/>(1.5)"]
+    P07["07 取込CLI<br/>(1.6)"]
+    P08["08 ハッシュ冪等性<br/>(1.7)"]
+    P09["09 月次サマリSQL<br/>(1.8)"]
+
+    P02 --> P03
+    P03 --> P04
+    P04 --> P05
+    P04 --> P06
+    P05 --> P07
+    P06 --> P07
+    P03 --> P08
+    P07 --> P08
+    P07 --> P09
+
+    classDef critical stroke:#d33,stroke-width:3px;
+    class P02,P03,P04,P07 critical;
+```
+
+赤線（クリティカルパス）の根拠: スキーマ → 共通型 → ABC → CLI が直列で詰まり、ここが詰まると Phase1 が完了しない。アダプタ（05/06）は並行可能、検証系（08/09）は CLI 完了後の並行作業。
+
+### 循環依存の不在
+
+依存グラフは DAG であり循環はない（02 が依存元なし、後段は常に番号の小さいタスクのみを参照）。
+
+## 5. Phase1 完了条件カバレッジ
+
+`docs/plans/01-development-plan.md` §3.1 の 4 条件と本プラン群の対応を再掲（本ファイル §1 と整合）。
+
+| 完了条件 | 主担当プラン | 補強プラン |
+|---|---|---|
+| (a) `alembic upgrade head` 冪等 | `02-phase1-db-schema-and-migrations.md` | – |
+| (b) 同一 CSV 2 回投入で行数増えず | `07-phase1-ingest-cli.md` | `08-phase1-hash-idempotency-tests.md` |
+| (c) 月次サマリ SQL が手計算と一致 | `09-phase1-monthly-summary-sql.md` | `07-phase1-ingest-cli.md`（投入元） |
+| (d) 全ユニットテスト緑 / pyright クリーン | 全プラン横断 | – |
+
+## 6. 品質ゲート
+
+`docs/plans/01-development-plan.md` §7 を Phase1 部分に絞って再掲。
+
+- ユニットテスト + ゴールデンマスタテストが全件緑（10 秒以内）。
+- `pyright` クリーン、`ruff` 違反ゼロ。
+- サンプル CSV 取込 → 月次サマリが手計算と一致。
+- 各タスクの「受入条件」がすべて満たされている。
+
+## 7. プランファイル一覧（参照用）
+
+- `02-phase1-db-schema-and-migrations.md`
+- `03-phase1-domain-types.md`
+- `04-phase1-ingest-adapter-base.md`
+- `05-phase1-mufg-csv-adapter.md`
+- `06-phase1-smbc-csv-adapter.md`
+- `07-phase1-ingest-cli.md`
+- `08-phase1-hash-idempotency-tests.md`
+- `09-phase1-monthly-summary-sql.md`
+
+## 8. Phase1 完了後の次ステップ
+
+Phase 2 以降のタスク分解は本ファイルの責務外。`docs/plans/01-development-plan.md` §4.2〜§4.4 を参照し、Phase 2 に着手する時点で同様の `1X-phase2-*.md`（または同等の連番）として展開する。

--- a/tests/unit/test_phase1_plan_documents.py
+++ b/tests/unit/test_phase1_plan_documents.py
@@ -1,0 +1,308 @@
+"""``docs/plans/`` Phase1 タスクプラン文書群の構造検証テスト。
+
+このテストは、Phase1 タスク分解プランファイル群
+(``docs/plans/02-*.md`` 〜 ``docs/plans/09-*.md``) と、それらを俯瞰する
+インデックスファイル (``docs/plans/10-*.md``) が、指示書および計画レポートで
+定めた以下の契約を満たすことを構造的に検証する。
+
+検証対象（指示書「成果物」と計画レポート §2.1 タスク要素一覧）:
+
+1. 02〜09 の連番でタスクプランファイル 8 本が漏れなく存在する
+2. インデックスファイルが 10 番台で 1 本だけ存在する
+3. 各プランファイルが必須 10 セクションを含む
+   - タスク概要 / 目的・背景 / スコープ / 依存タスク / 後続タスク /
+     対象ファイル/モジュール / 実装方針 / 受入条件 / テスト計画 /
+     想定 issue タイトル・ブランチ名
+4. 各プランファイルが原典 ``01-development-plan.md`` §6 のブランチ名を
+   本文に保持する（タスク識別の正本との不整合を即時検出するため）
+5. インデックスファイルが Phase1 全体ゴール / タスク一覧表 /
+   実装順序 / 依存関係図 の必須要素を含み、8 つのプランファイル名を
+   いずれも参照している
+
+設計準拠:
+- 指示書「タスク指示書: Phase1 のタスク分解と実装プラン作成」
+- 計画レポート §2 要件棚卸し / §6 連番割当
+- ``01-development-plan.md`` §4.1 / §5 / §6（タスク粒度・依存・ブランチ名の正本）
+- ``agent-rules/11-testing-strategy.md``（振る舞い駆動 TDD）
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+# 原典 ``01-development-plan.md`` §4.1 / §6 から導出した、各タスクプラン
+# ファイルが満たすべき正本情報。プランナがスラッグ部分を変更しても、
+# 連番プレフィックスとブランチ名の整合は固定であるべきという立場で固定する。
+#
+# (連番プレフィックス, 原典タスクID, 原典ブランチ名)
+PHASE1_TASK_SPEC: list[tuple[str, str, str]] = [
+    ("02", "1.1", "feature/db-schema-initial"),
+    ("03", "1.2", "feature/domain-types"),
+    ("04", "1.3", "feature/ingest-adapter-base"),
+    ("05", "1.4", "feature/adapter-mufg-csv"),
+    ("06", "1.5", "feature/adapter-smbc-csv"),
+    ("07", "1.6", "feature/ingest-cli"),
+    ("08", "1.7", "feature/hash-idempotency-tests"),
+    ("09", "1.8", "feature/monthly-summary-sql"),
+]
+
+# 各プランファイルに必須の 10 セクション。
+# 値は「いずれかの組み合わせがいずれかの見出し行に含まれていればOK」という
+# 代替指定リスト。例えば「受入条件」は ``Acceptance Criteria`` の英語表記も許容する。
+REQUIRED_PLAN_SECTIONS: list[tuple[str, list[tuple[str, ...]]]] = [
+    ("タスク概要", [("タスク概要",)]),
+    ("目的・背景", [("目的", "背景")]),
+    ("スコープ", [("スコープ",)]),
+    ("依存タスク", [("依存タスク",)]),
+    ("後続タスク", [("後続タスク",)]),
+    ("対象ファイル/モジュール", [("対象ファイル",), ("対象モジュール",)]),
+    ("実装方針", [("実装方針",)]),
+    ("受入条件", [("受入条件",), ("Acceptance Criteria",)]),
+    ("テスト計画", [("テスト計画",)]),
+    ("想定issueタイトル/ブランチ名", [("ブランチ名",)]),
+]
+
+# インデックスファイルに必須のセクション要素。
+INDEX_REQUIRED_SECTIONS: list[tuple[str, list[tuple[str, ...]]]] = [
+    ("Phase1 全体ゴール", [("Phase1", "ゴール"), ("Phase 1", "ゴール")]),
+    ("タスク一覧表", [("タスク一覧",)]),
+    ("実装順序", [("実装順序",), ("実装順",)]),
+    ("依存関係図", [("依存関係",)]),
+]
+
+
+@pytest.fixture
+def plans_dir(repo_root: Path) -> Path:
+    """``docs/plans/`` ディレクトリの絶対パスを返す。
+
+    ``repo_root`` (conftest.py) が function スコープのため、本フィクスチャも
+    function スコープに合わせる（pytest の ScopeMismatch を回避するため）。
+    """
+    return repo_root / "docs" / "plans"
+
+
+def _iter_heading_texts(content: str) -> Iterable[str]:
+    """Markdown 見出し行の見出しテキスト部分のみを順に返す。"""
+    for line in content.splitlines():
+        stripped = line.lstrip()
+        if not stripped.startswith("#"):
+            continue
+        # 連続する '#' を取り除き、見出しテキスト部のみ残す。
+        yield stripped.lstrip("#").strip()
+
+
+def _has_section(content: str, alternatives: list[tuple[str, ...]]) -> bool:
+    """``alternatives`` のいずれかの組（AND 条件）に合致する見出しが存在するか。
+
+    ``alternatives`` は OR、各タプル内のキーワードは AND として扱う。
+    例: ``[("目的", "背景")]`` は「目的」と「背景」の両方を含む見出しを要求。
+    例: ``[("受入条件",), ("Acceptance Criteria",)]`` は片方でも見出しに
+        含まれていれば成立。
+    """
+    headings = list(_iter_heading_texts(content))
+    for keyword_set in alternatives:
+        for heading in headings:
+            if all(kw in heading for kw in keyword_set):
+                return True
+    return False
+
+
+def test_docs_plansディレクトリが存在する(plans_dir: Path) -> None:
+    """前提条件: 出力先ディレクトリ ``docs/plans/`` が存在すること。"""
+    assert plans_dir.is_dir(), (
+        f"Phase1 プラン出力先ディレクトリが存在しません: {plans_dir}"
+    )
+
+
+def test_phase1のタスクプランが02から09の連番で8本そろう(plans_dir: Path) -> None:
+    """指示書「実装順序に従って連番を付与」の契約を検証する。
+
+    既存ファイル ``00-initial-design.md`` / ``01-development-plan.md`` を
+    避けて 02 から開始することを必須とし、抜け番・重複番がないことを確認する。
+    """
+    found = sorted(plans_dir.glob("0[2-9]-*.md"))
+    found_prefixes = {p.name[:2] for p in found}
+    expected_prefixes = {f"0{i}" for i in range(2, 10)}
+
+    assert found_prefixes == expected_prefixes, (
+        f"02〜09 の連番プランファイルに過不足があります。\n"
+        f"  期待: {sorted(expected_prefixes)}\n"
+        f"  実在: {sorted(found_prefixes)}\n"
+        f"  発見ファイル: {[p.name for p in found]}"
+    )
+
+
+def test_phase1インデックスファイルが10番台で1本のみ存在する(plans_dir: Path) -> None:
+    """指示書「タスクプランの最終番号の次の番号」の契約を検証する。
+
+    インデックスファイルは Phase1 を俯瞰する唯一の入口になるため、
+    複数本生成されると到達経路が分散して指示書の意図に反する。
+    """
+    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+    assert len(index_files) == 1, (
+        f"Phase1 インデックスファイルは 10 番台で 1 本のみ想定。\n"
+        f"  発見数: {len(index_files)}\n"
+        f"  発見ファイル: {[p.name for p in index_files]}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("number_prefix", "task_id", "branch"),
+    PHASE1_TASK_SPEC,
+    ids=[f"{prefix}={task_id}" for prefix, task_id, _ in PHASE1_TASK_SPEC],
+)
+def test_各プランファイルが原典のブランチ名を保持する(
+    plans_dir: Path, number_prefix: str, task_id: str, branch: str
+) -> None:
+    """原典 ``01-development-plan.md`` §6 のブランチ名と完全一致すること。
+
+    ブランチ名は 1 issue / 1 PR の識別子であり、原典との不整合は
+    トレーサビリティ崩壊を意味するため、文字列一致で厳密に検証する。
+    """
+    matches = list(plans_dir.glob(f"{number_prefix}-*.md"))
+    assert len(matches) == 1, (
+        f"連番 {number_prefix} のプランファイルが一意に特定できません: {matches}"
+    )
+    plan_file = matches[0]
+    content = plan_file.read_text(encoding="utf-8")
+    assert branch in content, (
+        f"プランファイル {plan_file.name} (Phase {task_id}) に原典ブランチ名 "
+        f"'{branch}' が含まれていません"
+    )
+
+
+@pytest.mark.parametrize(
+    ("number_prefix", "task_id", "branch"),
+    PHASE1_TASK_SPEC,
+    ids=[f"{prefix}={task_id}" for prefix, task_id, _ in PHASE1_TASK_SPEC],
+)
+def test_各プランファイルが必須10セクションを含む(
+    plans_dir: Path, number_prefix: str, task_id: str, branch: str
+) -> None:
+    """指示書「各プランファイルに含める内容（必須セクション）」を網羅検証する。
+
+    Markdown 見出し行（``#`` から始まる行）にセクション名が現れることを必須とし、
+    本文中の単なる言及だけでは合格としない（構造としての見出し化を要求）。
+    """
+    del task_id, branch  # この検証ではセクション名のみ評価する
+    matches = list(plans_dir.glob(f"{number_prefix}-*.md"))
+    assert len(matches) == 1, (
+        f"連番 {number_prefix} のプランファイルが一意に特定できません: {matches}"
+    )
+    plan_file = matches[0]
+    content = plan_file.read_text(encoding="utf-8")
+
+    missing: list[str] = []
+    for section_label, alternatives in REQUIRED_PLAN_SECTIONS:
+        if not _has_section(content, alternatives):
+            missing.append(section_label)
+
+    assert not missing, (
+        f"{plan_file.name} に必須セクションが見出しとして存在しません: {missing}"
+    )
+
+
+def test_インデックスファイルが必須セクションを含む(plans_dir: Path) -> None:
+    """指示書「インデックスファイルに含める内容」を網羅検証する。"""
+    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+    assert len(index_files) == 1, (
+        f"インデックスファイルが一意に特定できません: "
+        f"{[p.name for p in index_files]}"
+    )
+    index_file = index_files[0]
+    content = index_file.read_text(encoding="utf-8")
+
+    missing: list[str] = []
+    for section_label, alternatives in INDEX_REQUIRED_SECTIONS:
+        if not _has_section(content, alternatives):
+            missing.append(section_label)
+
+    assert not missing, (
+        f"{index_file.name} に必須セクションが見出しとして存在しません: {missing}"
+    )
+
+
+def test_インデックスファイルが8つのプランファイルすべてを参照する(
+    plans_dir: Path,
+) -> None:
+    """インデックスから各プランへの到達経路（Markdown リンク）を検証する。
+
+    指示書「全タスクの一覧、依存関係、実装順序を俯瞰できる構成」かつ
+    「依存関係はプランファイル名で参照」の契約に基づき、すべての連番プラン
+    ファイル名がインデックス本文に登場することを必須とする。
+    """
+    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+    assert len(index_files) == 1, (
+        f"インデックスファイルが一意に特定できません: "
+        f"{[p.name for p in index_files]}"
+    )
+    index_content = index_files[0].read_text(encoding="utf-8")
+
+    plan_files = sorted(plans_dir.glob("0[2-9]-*.md"))
+    assert len(plan_files) == 8, "プランファイル本数が 8 ではないため前提崩壊"
+
+    missing_refs: list[str] = []
+    for plan_file in plan_files:
+        if plan_file.name not in index_content:
+            missing_refs.append(plan_file.name)
+
+    assert not missing_refs, (
+        f"インデックスファイル {index_files[0].name} から参照されていない "
+        f"プランファイルがあります: {missing_refs}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("number_prefix", "task_id", "branch"),
+    PHASE1_TASK_SPEC,
+    ids=[f"{prefix}={task_id}" for prefix, task_id, _ in PHASE1_TASK_SPEC],
+)
+def test_各プランファイルの依存タスク参照がプランファイル名形式に統一されている(
+    plans_dir: Path, number_prefix: str, task_id: str, branch: str
+) -> None:
+    """計画レポート「アンチパターン」の禁則を検証する。
+
+    依存タスクの記述が原典タスク番号 (例: 1.1) のままだと、本タスクで
+    導入したプランファイル名による相互参照が崩れる。各プランの「依存タスク」
+    セクション以降に少なくとも 1 件のプランファイル名 (``0X-*.md``) または
+    「なし」「無し」の明示があることを要求する。
+    """
+    del task_id, branch
+    matches = list(plans_dir.glob(f"{number_prefix}-*.md"))
+    assert len(matches) == 1
+    content = matches[0].read_text(encoding="utf-8")
+
+    # 「依存タスク」見出しから次の見出しまでの本文ブロックを切り出す。
+    lines = content.splitlines()
+    in_section = False
+    section_body: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip()
+            if "依存タスク" in heading:
+                in_section = True
+                continue
+            if in_section:
+                # 次の見出しに到達したらブロック終了
+                break
+        if in_section:
+            section_body.append(line)
+
+    body_text = "\n".join(section_body).strip()
+    assert body_text, (
+        f"{matches[0].name} に「依存タスク」セクションの本文がありません"
+    )
+
+    # 依存があれば 0X-*.md 形式で示すか、なければその旨が明示されていること。
+    has_plan_ref = any(
+        f"0{i}-" in body_text for i in range(2, 10)
+    )
+    declares_none = any(token in body_text for token in ("なし", "無し", "None"))
+    assert has_plan_ref or declares_none, (
+        f"{matches[0].name} の「依存タスク」セクションに、依存先プランファイル名 "
+        f"(0X-*.md) も「なし」表明もありません。本文:\n{body_text}"
+    )


### PR DESCRIPTION
## Summary
- Phase1 タスクプラン文書 8 本（`docs/plans/02〜09-phase1-*.md`）を追加。DB スキーマ／ドメイン型／ingest アダプタ基盤・MUFG・SMBC／CLI／ハッシュ冪等／月次サマリ SQL の実装手順を確定
- Phase1 全体俯瞰インデックス `docs/plans/10-phase1-overview.md` を追加（全タスクの一覧・実装順序・依存関係図）
- Phase1 タスクプラン文書群の構造検証テスト `tests/unit/test_phase1_plan_documents.py` を先行作成（連番・必須セクション・原典ブランチ名・依存参照形式の契約を固定）

## 背景
これまでローカル `develop` に直接コミットされていた 3 コミット（`c805b4e`, `a3f7327`, `e720363`）を `feature/phase1-plan-docs-baseline` ブランチに退避し、`agent-rules/10-git-strategy.md` の「protected branches: NEVER commit directly to develop」を遵守するための後追い PR。コミット内容自体は不変（cherry-pick ではなく既存コミットの参照）。

## 後続 PR
- `#次番号` `feature/design-docs-per-service` — design ドキュメントのサービス別振り分け（本 PR を base にスタック）

## Test plan
- [ ] `uv run pytest tests/unit/test_phase1_plan_documents.py` 全件 PASS
- [ ] `uv run pytest -x` 全件 PASS（develop ベースで）