### PR TITLE
実装プラン整理: サービス別タスク振り分けと design 参照パス追従

### DIFF
--- a/docs/plans/11-phase1-service-assignments.md
+++ b/docs/plans/11-phase1-service-assignments.md
@@ -1,0 +1,117 @@
+---
+title: Phase1 サービス別タスク振り分けインデックス
+phase: 1
+status: Ready
+parent: docs/plans/10-phase1-overview.md
+last_updated: 2026-05-01
+---
+
+# Phase1 サービス別タスク振り分けインデックス
+
+`docs/plans/10-phase1-overview.md`（Phase1 全体俯瞰）と `docs/plans/01-development-plan.md` §4.1（タスク詳細）を、`compose.yml` のサービス（コンテナ）単位に振り分けたディスパッチテーブル。各サービスごとのサブディレクトリにある指示書（Coder / Planner サブエージェントが直接参照する実装タスクシート）の入口。
+
+## 1. サービス × Phase1 タスク マトリクス
+
+`compose.yml` のサービス名で振り分け。`postgres`（DB）と `worker`（取込パイプライン）に責務を集約し、`api`/`ui` は Phase1 では新規タスクなし。
+
+| サービス | Phase 1.1 | 1.2 | 1.3 | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 | 担当数 |
+|---|---|---|---|---|---|---|---|---|---|
+| `postgres` | ● | – | – | – | – | – | – | – | 1 |
+| `worker` | – | ● | ● | ● | ● | ● | ● | ● | 7 |
+| `api` | – | – | – | – | – | – | – | – | 0 |
+| `ui` | – | – | – | – | – | – | – | – | 0 |
+
+`postgres` は **スキーマ正本**（Alembic migrations）を持つコンテナ。`worker` はそれを使うアプリケーション層全般を担う。
+
+## 2. サブディレクトリ構成
+
+```
+docs/plans/
+├── 10-phase1-overview.md           # Phase1 全体俯瞰（既存）
+├── 11-phase1-service-assignments.md # 本ファイル（サービス振り分け）
+├── postgres/
+│   ├── README.md                    # postgres サービス Phase1 一覧
+│   └── 01-schema-migrations.md      # Phase 1.1 (源: 02-phase1-...md)
+├── worker/
+│   ├── README.md                    # worker サービス Phase1 一覧
+│   ├── 01-domain-types.md           # Phase 1.2 (源: 03-phase1-...md)
+│   ├── 02-ingest-adapter-base.md    # Phase 1.3 (源: 04-phase1-...md)
+│   ├── 03-mufg-csv-adapter.md       # Phase 1.4 (源: 05-phase1-...md)
+│   ├── 04-smbc-csv-adapter.md       # Phase 1.5 (源: 06-phase1-...md)
+│   ├── 05-ingest-cli.md             # Phase 1.6 (源: 07-phase1-...md)
+│   ├── 06-hash-idempotency-tests.md # Phase 1.7 (源: 08-phase1-...md)
+│   └── 07-monthly-summary-sql.md    # Phase 1.8 (源: 09-phase1-...md)
+├── api/
+│   └── README.md                    # Phase1 担当タスクなし宣言
+└── ui/
+    └── README.md                    # Phase1 担当タスクなし宣言
+```
+
+各サービスサブディレクトリの指示書は **原典プラン（`docs/plans/02〜09-phase1-*.md`）の翻案** であり、原典は変更しない。原典との乖離時は **原典優先**（`docs/plans/01-development-plan.md` §1.4）。
+
+## 3. 現在の実装状況スナップショット（2026-05-01 時点）
+
+`docs/plans/02〜09` の 8 タスクは **すべて未着手**。既に存在するのは Phase 0 のインフラ：
+
+| 完了済（Phase 0） | パス |
+|---|---|
+| Docker Compose 構成 | `compose.yml`, `compose.override.yml`, `Caddyfile` |
+| Postgres コンテナ | `compose.yml` `postgres` サービス（`postgres:16-alpine`） |
+| Worker heartbeat ループ | `src/kakeibo/worker/main.py`, `worker/Dockerfile` |
+| API ヘルスチェック | `src/kakeibo/api/app.py` `/health`, `api/Dockerfile` |
+| UI 雛形 | `ui/app/{layout,page}.tsx`, `ui/Dockerfile` |
+| 設定ローダー | `src/kakeibo/config.py`, `src/kakeibo/logging.py` |
+| Alembic 設定 | `alembic.ini`, `alembic/env.py`（versions は空） |
+| DB セッション骨格 | `src/kakeibo/db/session.py` |
+| Phase1 計画文書 | `docs/plans/02〜10` |
+| 計画文書の構造検証テスト | `tests/unit/test_phase1_plan_documents.py` |
+
+Phase1 のドメインロジック（`src/kakeibo/domain/`, `src/kakeibo/adapters/`, `src/kakeibo/ingest/`）は **すべて namespace package のプレースホルダ** のみで、実装は本タスクシート群でこれから着手する。
+
+## 4. 推奨実装フロー（モードB: Claude単体サブエージェント協調）
+
+`agent-rules/91-claude-subagent-coding.md` に従い、メインClaudeはオーケストレーターに徹する。実装フローは `docs/plans/10-phase1-overview.md` §3 を踏襲：
+
+```
+1. postgres/01           （Planner → Coder → Reviewer → Git-composer）
+2. worker/01            （同上）
+3. worker/02            （同上）
+4. worker/03 ‖ worker/04（Coder 2 体並列起動可能）
+5. worker/05            （同上）
+6. worker/06 ‖ worker/07（並列可能）
+```
+
+各タスクは 1 ブランチ・1 PR 単位（`agent-rules/10-git-strategy.md`）。コミットはアトミックに分割し、コミットメッセージは日本語 1〜2 文（`機能:` / `修正:` / `テスト:` / `文書:` 等）。
+
+## 5. Phase1 完了条件カバレッジ
+
+`docs/plans/01-development-plan.md` §3.1 の 4 条件と本ディレクトリ群の対応：
+
+| 完了条件 | 主担当 | 補強 |
+|---|---|---|
+| (a) `alembic upgrade head` 冪等 | `postgres/01` | – |
+| (b) 同一 CSV 2 回投入で行数増えず | `worker/05` | `worker/06` |
+| (c) 月次サマリ SQL が手計算と一致 | `worker/07` | `worker/05`（投入元） |
+| (d) 全ユニットテスト緑、`pyright` クリーン | 全タスク横断 | – |
+
+## 6. 上位文書との関係
+
+| 文書 | 関係 |
+|---|---|
+| `docs/plans/00-initial-design.md` | 設計書 v1.0（変更には ADR が必要） |
+| `docs/plans/01-development-plan.md` | 全 Phase の本体プラン |
+| `docs/plans/10-phase1-overview.md` | Phase1 全体俯瞰（タスク一覧・依存・実装順） |
+| **`docs/plans/11-phase1-service-assignments.md`** | **本ファイル**：サービス別の振り分け |
+| `docs/plans/02〜09-phase1-*.md` | Phase1 タスクごとの原典プラン（不変） |
+| `docs/plans/{postgres,worker,api,ui}/` | サービス別実装タスクシート（本タスクで作成） |
+
+## 7. Phase 2 以降の拡張方針
+
+Phase 2 着手時に同様のサービス振り分けを行う。Phase 2 では：
+
+- `worker` サービスに Phase 2.1〜2.8（Watcher / Gmail / メールパーサ / PayPal / cron）が集中
+- `worker` に常駐サービス機能（watchdog）が加わるため、`docs/plans/worker/` に 2X 系の指示書が増える
+- `docs/plans/postgres/` には新規スキーマ追加 ADR があれば対応指示書を増やす可能性がある
+- `api` / `ui` は引き続き Phase 2 ではタスクなし（Phase 3 で本格着手）
+
+サブディレクトリ構成は不変・追加方式で運用する。

--- a/docs/plans/12-phase2-service-assignments.md
+++ b/docs/plans/12-phase2-service-assignments.md
@@ -1,0 +1,181 @@
+---
+title: Phase2 サービス別タスク振り分けインデックス
+phase: 2
+status: Ready
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-05-01
+---
+
+# Phase2 サービス別タスク振り分けインデックス
+
+`docs/plans/01-development-plan.md` §4.2 Phase 2「自動化」のタスク 2.1〜2.8 を、`compose.yml` のサービス（コンテナ）単位に振り分けたディスパッチテーブル。Phase1 の `11-phase1-service-assignments.md` と同じ枠組みで運用する。
+
+## 1. Phase2 全体ゴール
+
+`docs/plans/01-development-plan.md` §3.2 から要約。
+
+> **ゴール**: `/inbox` への CSV 投下 → 5 分以内に DB 反映。Gmail 経由で EC 注文確認メールが自動取込。PayPal API から日次取引が同期。
+
+### 完了条件
+
+| ID | 条件 |
+|---|---|
+| (a) | Watcher が起動状態で CSV 投下から 5 分以内に取引が DB に現れる |
+| (b) | Amazon / 楽天市場 / Yahoo!ショッピングのサンプルメールから取引が抽出される |
+| (c) | PayPal Sandbox API から取引が取得できる |
+| (d) | パース失敗ファイルが dead letter ディレクトリに移動される |
+| (e) | 統合テスト（実 Postgres + 模擬メール）が緑 |
+
+## 2. サービス × Phase2 タスク マトリクス
+
+| サービス | 2.1 | 2.2 | 2.3 | 2.4 | 2.5 | 2.6 | 2.7 | 2.8 | 担当数 |
+|---|---|---|---|---|---|---|---|---|---|
+| `postgres` | – | – | – | – | – | – | – | – | 0 |
+| `worker` | ● | ● | ● | ● | ● | ● | ● | ● | 8 |
+| `api` | – | – | – | – | – | – | – | – | 0 |
+| `ui` | – | – | – | – | – | – | – | – | 0 |
+
+Phase2 は **すべて `worker` サービスに集約** される。Phase1 で作った取込CLI（`src/kakeibo/ingest/cli.py`）と共通アダプタ（`src/kakeibo/adapters/`）の上に、watchdog / メールパーサ / 外部 API クライアント / cron スケジューラを積み上げる構造。
+
+`compose.yml` の `worker` サービス（`worker/Dockerfile`）の改修は 2.8 cron バッチ運用化で発生する。`postgres` のスキーマは Phase1 で確定済みで Phase2 では変更しない（メール取引・PayPal 取引も `transactions` テーブルに正規化済みの形で投入）。
+
+## 3. サブディレクトリ構成
+
+```
+docs/plans/
+├── 12-phase2-service-assignments.md  # 本ファイル（Phase2 振り分け）
+├── postgres/Ph2/
+│   └── README.md                      # 担当タスクなし
+├── worker/Ph2/
+│   ├── README.md                      # worker サービス Phase2 一覧
+│   ├── 01-watcher-service.md          # Phase 2.1
+│   ├── 02-archive-and-dead-letter.md  # Phase 2.2
+│   ├── 03-gmail-mcp-client.md         # Phase 2.3
+│   ├── 04-parser-amazon-mail.md       # Phase 2.4
+│   ├── 05-parser-rakuten-mail.md      # Phase 2.5
+│   ├── 06-parser-yahoo-mail.md        # Phase 2.6
+│   ├── 07-adapter-paypal-api.md       # Phase 2.7
+│   └── 08-cron-batch-runner.md        # Phase 2.8
+├── api/Ph2/
+│   └── README.md                      # 担当タスクなし
+└── ui/Ph2/
+    └── README.md                      # 担当タスクなし
+```
+
+Phase2 の **原典は `docs/plans/01-development-plan.md` §4.2** のみ（Phase1 のような独立詳細プランファイル `12-phase2-*.md` は **作らない方針**：原典が必要十分に簡潔で、サービス別指示書だけで Coder が着手できるため）。原典との乖離時は原典優先。
+
+## 4. 現在の実装状況スナップショット（2026-05-01 時点）
+
+### Phase2 関連で既に存在するもの（Phase 0 で配備済み）
+
+| 資産 | パス | 用途 |
+|---|---|---|
+| inbox / archive / dead_letter ディレクトリ | `./{inbox,archive,dead_letter}/.gitkeep` | Watcher / Archiver の I/O ボリューム |
+| secrets ディレクトリ | `./secrets/{gmail_oauth_token.json,paypal_api_secret.txt,...}` | Docker secret の供給元（`.example` も配置済み） |
+| `compose.yml` `worker` サービス | volume マウント / 環境変数（`INBOX_PATH`, `GMAIL_OAUTH_TOKEN_FILE`, `PAYPAL_API_SECRET_FILE`）すでに宣言済 | – |
+| Settings ローダー | `src/kakeibo/config.py` `gmail_oauth_token_path`, `paypal_api_secret` フィールド済み | Phase 2.3 / 2.7 で参照 |
+| 依存宣言 | `pyproject.toml` `[project.optional-dependencies].mail` に `mail-parser`, `beautifulsoup4`, `lxml` | Phase 2.4〜2.6 で有効化 |
+| `worker/Dockerfile` | 既に `--extra mail --extra pdf --extra llm` でビルド済 | Phase 2.x で追加 build 不要 |
+
+### 未着手（Phase2 で実装）
+
+| 領域 | パス | 帰属タスク |
+|---|---|---|
+| watchdog Watcher 本体 | `src/kakeibo/ingest/watcher.py`（未作成） | `worker/Ph2/01` |
+| アーカイブ / dead letter ロジック | `src/kakeibo/ingest/archiver.py`（未作成） | `worker/Ph2/02` |
+| Gmail MCP クライアント | `src/kakeibo/adapters/gmail/`（未作成） + `RawMail` ドメイン型 | `worker/Ph2/03` |
+| メールパーサ群（Amazon / 楽天 / Yahoo） | `src/kakeibo/adapters/mail/{amazon,rakuten,yahoo}.py` | `worker/Ph2/04〜06` |
+| PayPal API クライアント | `src/kakeibo/adapters/paypal.py` | `worker/Ph2/07` |
+| cron バッチランナー | `src/kakeibo/worker/scheduler.py` + `worker/Dockerfile` 改修 | `worker/Ph2/08` |
+
+### Phase2 の前提（Phase1 完了が必要）
+
+`worker/Ph1/` のすべて（`01〜07`）と `postgres/Ph1/01`（DBスキーマ）が完了していることが前提。**Phase1 完了前に Phase2 着手はしない**（クリティカルパス違反）。
+
+## 5. タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典（行範囲） | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 2.1 watchdog Watcher サービス | [`worker/Ph2/01-watcher-service.md`](./worker/Ph2/01-watcher-service.md) | §4.2 L211-221 | `feature/watcher-service` | 🔴 高 |
+| 02 | Phase 2.2 アーカイブ移動 + dead letter | [`worker/Ph2/02-archive-and-dead-letter.md`](./worker/Ph2/02-archive-and-dead-letter.md) | §4.2 L223-233 | `feature/archive-and-dead-letter` | 🟠 中 |
+| 03 | Phase 2.3 Gmail MCP 接続 | [`worker/Ph2/03-gmail-mcp-client.md`](./worker/Ph2/03-gmail-mcp-client.md) | §4.2 L235-245 | `feature/gmail-mcp-client` | 🔴 高 |
+| 04 | Phase 2.4 Amazon メールパーサ | [`worker/Ph2/04-parser-amazon-mail.md`](./worker/Ph2/04-parser-amazon-mail.md) | §4.2 L247-257 | `feature/parser-amazon-mail` | 🟡 中 |
+| 05 | Phase 2.5 楽天市場 メールパーサ | [`worker/Ph2/05-parser-rakuten-mail.md`](./worker/Ph2/05-parser-rakuten-mail.md) | §4.2 L259-269 | `feature/parser-rakuten-mail` | 🟡 中 |
+| 06 | Phase 2.6 Yahoo!ショッピング メールパーサ | [`worker/Ph2/06-parser-yahoo-mail.md`](./worker/Ph2/06-parser-yahoo-mail.md) | §4.2 L271-281 | `feature/parser-yahoo-mail` | 🟡 中 |
+| 07 | Phase 2.7 PayPal API クライアント | [`worker/Ph2/07-adapter-paypal-api.md`](./worker/Ph2/07-adapter-paypal-api.md) | §4.2 L283-293 | `feature/adapter-paypal-api` | 🔴 高 |
+| 08 | Phase 2.8 cron バッチ運用化 | [`worker/Ph2/08-cron-batch-runner.md`](./worker/Ph2/08-cron-batch-runner.md) | §4.2 L295-305 | `feature/cron-batch-runner` | 🟠 中 |
+
+## 6. 依存関係図
+
+`docs/plans/01-development-plan.md` §5 の Phase2 部分を再掲。
+
+```mermaid
+flowchart TD
+    P16["Phase 1.6 取込CLI<br/>(完了前提)"]
+    P13["Phase 1.3 IngestAdapter ABC<br/>(完了前提)"]
+
+    P21["worker/Ph2/01<br/>Watcher (2.1)"]
+    P22["worker/Ph2/02<br/>Archive/DeadLetter (2.2)"]
+    P23["worker/Ph2/03<br/>Gmail MCP (2.3)"]
+    P24["worker/Ph2/04<br/>Amazonパーサ (2.4)"]
+    P25["worker/Ph2/05<br/>楽天パーサ (2.5)"]
+    P26["worker/Ph2/06<br/>Yahooパーサ (2.6)"]
+    P27["worker/Ph2/07<br/>PayPal API (2.7)"]
+    P28["worker/Ph2/08<br/>cronバッチ (2.8)"]
+
+    P16 --> P21
+    P21 --> P22
+    P13 --> P23
+    P23 --> P24
+    P23 --> P25
+    P23 --> P26
+    P13 --> P27
+    P24 --> P28
+    P25 --> P28
+    P26 --> P28
+    P27 --> P28
+
+    classDef critical stroke:#d33,stroke-width:3px;
+    class P21,P22,P23,P28 critical;
+```
+
+## 7. 推奨実装順序
+
+直列上流（クリティカルパス）：
+
+```
+worker/Ph2/01 (Watcher) → worker/Ph2/02 (Archive/DLQ)
+worker/Ph2/03 (Gmail MCP) → worker/Ph2/04 ‖ 05 ‖ 06 (メールパーサ並列)
+worker/Ph2/07 (PayPal API)
+                                                      ↓
+                            worker/Ph2/08 (cron バッチ; 04/05/06/07 完了後)
+```
+
+並列可能ペア：
+- `worker/Ph2/01` と `worker/Ph2/03` は独立（File watcher と Gmail は別レーン）
+- `worker/Ph2/04 / 05 / 06` は Gmail MCP 完了後に 3 体の Coder で並列起動可
+- `worker/Ph2/07` は他レーンと完全独立（OAuth ではなく API Secret）
+
+## 8. 共通の前提
+
+| 項目 | 内容 |
+|---|---|
+| Phase1 完了 | `worker/Ph1/05` (取込CLI) と `postgres/Ph1/01` (スキーマ) が緑であること |
+| Docker secret | `secrets/{gmail_oauth_token.json, paypal_api_secret.txt}` が運用環境に配置済（開発時は `.example` ベース） |
+| 環境変数 | `INBOX_PATH=/inbox`, `ARCHIVE_PATH=/archive`, `DEAD_LETTER_PATH=/dead_letter`, `GMAIL_OAUTH_TOKEN_FILE`, `PAYPAL_API_SECRET_FILE` は `compose.yml` で宣言済み |
+| 依存パッケージ | `pyproject.toml` `[project.optional-dependencies].mail`（mail-parser, beautifulsoup4, lxml）を `--extra mail` で導入 |
+| ログ | `structlog` で構造化ログ。トークン・シークレットは絶対にログ出力しない（`agent-rules/12-security-guidelines.md`） |
+
+## 9. Phase2 完了条件カバレッジ
+
+| 完了条件 | 主担当 | 補強 |
+|---|---|---|
+| (a) CSV 投下 5 分以内に DB 反映 | `worker/Ph2/01` | `worker/Ph2/02` |
+| (b) Amazon/楽天/Yahoo メールから取引抽出 | `worker/Ph2/04` / `05` / `06` | `worker/Ph2/03` |
+| (c) PayPal Sandbox から取引取得 | `worker/Ph2/07` | – |
+| (d) パース失敗ファイルが dead letter へ | `worker/Ph2/02` | `worker/Ph2/01` |
+| (e) 統合テスト緑 | 全タスク横断 + `worker/Ph2/08` | – |
+
+## 10. Phase 3 への申し送り
+
+Phase 2 完了時点で Phase 3 着手準備が整う。Phase 3 は `api`（Flask REST API）と `ui`（React Dashboard）に重心が移る（`docs/plans/01-development-plan.md` §4.3）。Phase 3 着手時に `docs/plans/{api,ui}/Ph3/` を新設する。

--- a/docs/plans/13-phase3-service-assignments.md
+++ b/docs/plans/13-phase3-service-assignments.md
@@ -1,0 +1,209 @@
+---
+title: Phase3 サービス別タスク振り分けインデックス
+phase: 3
+status: Ready
+parent: docs/plans/01-development-plan.md
+last_updated: 2026-05-01
+---
+
+# Phase3 サービス別タスク振り分けインデックス
+
+`docs/plans/01-development-plan.md` §4.3 Phase 3「UX」のタスク 3.1〜3.6 を、`compose.yml` のサービス（コンテナ）単位に振り分けたディスパッチテーブル。Phase 1 の `11-phase1-service-assignments.md` / Phase 2 の `12-phase2-service-assignments.md` と同じ枠組みで運用する。Plannerによる Phase 3 分析の成果物。
+
+## 1. Phase3 全体ゴール
+
+`docs/plans/01-development-plan.md` §3.3 から要約。
+
+> **ゴール**: React Dashboard で残高推移・カテゴリ別支出・ポートフォリオ構成が可視化され、UI からカテゴリルールを編集できる。
+
+### 完了条件
+
+| ID | 条件 |
+|---|---|
+| (a) | Flask REST API が残高 / 取引 / カテゴリ / ルール の CRUD を提供する |
+| (b) | UI で月次推移グラフ・カテゴリ別支出・保有資産が表示される |
+| (c) | UI からルール追加・更新・削除が可能 |
+| (d) | Playwright e2e で主要シナリオが緑 |
+| (e) | `tsc --strict` クリーン |
+
+## 2. サービス × Phase3 タスク マトリクス
+
+| サービス | 3.1 Flask API | 3.2 React 雛形 | 3.3 月次推移 | 3.4 カテゴリ別 | 3.5 ポートフォリオ | 3.6 ルール編集UI | 主担当数 |
+|---|---|---|---|---|---|---|---|
+| `postgres` | – | – | – | – | – | – | 0 |
+| `api` | ● | – | ◐ | ◐ | ◐ | ◐ | 1 + 補助3 |
+| `worker` | – | – | – | – | – | – | 0 |
+| `ui` | – | ● | ● | ● | ● | ● | 5 |
+
+凡例: ● 主担当 / ◐ 補助（小規模追加） / – 担当なし
+
+### 切り分け方針（Planner判断）
+
+- **3.3〜3.5 は集計エンドポイントを必要とする**ため、`api/Ph3/02-aggregation-endpoints.md` として 3.1 から派生させて分離（原典 3.1 の受入基準は CRUD 止まりで集計 API は明示されていない）。
+- **3.6 は API と UI の両方が主担当**。dry-run プレビューエンドポイントを `api/Ph3/03-rule-dry-run-endpoint.md` に切り出し、ルール CRUD 自体は 3.1 に統合。
+- **完了条件 (d) Playwright e2e** は横断タスクとして `ui/Ph3/06-e2e-playwright.md` に独立配置。
+
+## 3. サブディレクトリ構成
+
+```
+docs/plans/
+├── 13-phase3-service-assignments.md          # 本ファイル（Phase3 振り分け）
+├── postgres/Ph3/
+│   └── README.md                              # 担当タスクなし宣言
+├── api/Ph3/
+│   ├── README.md                              # api サービス Phase3 一覧
+│   ├── 01-flask-rest-api.md                   # Phase 3.1 主担当（CRUD + OpenAPI + 認証）
+│   ├── 02-aggregation-endpoints.md            # Phase 3.3〜3.5 補助（集計 API）
+│   └── 03-rule-dry-run-endpoint.md            # Phase 3.6 補助（プレビュー）
+├── worker/Ph3/
+│   └── README.md                              # 担当タスクなし宣言
+└── ui/Ph3/
+    ├── README.md                              # ui サービス Phase3 一覧
+    ├── 01-react-dashboard-scaffold.md         # Phase 3.2
+    ├── 02-monthly-trend-chart.md              # Phase 3.3
+    ├── 03-category-spending-view.md           # Phase 3.4
+    ├── 04-portfolio-view.md                   # Phase 3.5
+    ├── 05-rule-editor-ui.md                   # Phase 3.6
+    └── 06-e2e-playwright.md                   # 完了条件 (d) Playwright e2e（横断）
+```
+
+Phase 3 でも **原典は `docs/plans/01-development-plan.md` §4.3 のみ**（Phase 1 のような独立詳細プランファイルは作らない方針を踏襲）。原典との乖離時は原典優先。
+
+## 4. 現在の実装状況スナップショット（2026-05-01 時点）
+
+### Phase3 関連で既に存在するもの（Phase 0 で配備済み）
+
+| 資産 | パス | 用途 |
+|---|---|---|
+| Flask アプリファクトリ | `src/kakeibo/api/app.py`（`/health` のみ） | Phase 3.1 で Blueprint を追加する起点 |
+| api Dockerfile | `api/Dockerfile`（uv マルチステージ、非 root） | Phase 3.1 でも変更不要 |
+| Next.js 14 App Router 雛形 | `ui/app/{layout,page}.tsx`、`ui/Dockerfile`（standalone build） | Phase 3.2 で拡張 |
+| 設定ローダー | `src/kakeibo/config.py` | 認証バイパスフラグ追加先 |
+| Flask / pydantic v2 依存 | `pyproject.toml` `[project.dependencies]` | 既宣言 |
+
+### 未着手（Phase3 で実装）
+
+| 領域 | パス | 帰属タスク |
+|---|---|---|
+| REST CRUD Blueprint 群 | `src/kakeibo/api/blueprints/` | `api/Ph3/01` |
+| pydantic スキーマ | `src/kakeibo/api/schemas/` | `api/Ph3/01` |
+| Tailscale ヘッダ認証 | `src/kakeibo/api/auth.py` | `api/Ph3/01` |
+| OpenAPI 自動生成 | `src/kakeibo/api/openapi.py` | `api/Ph3/01` |
+| リポジトリ層 | `src/kakeibo/db/repositories/` | `api/Ph3/01` |
+| 集計 SQL + API | `sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql`, `src/kakeibo/api/blueprints/aggregations.py` | `api/Ph3/02` |
+| ルール dry-run + Categorizer | `src/kakeibo/categorizer/`, `src/kakeibo/api/blueprints/rules.py` 拡張 | `api/Ph3/03` |
+| UI ライブラリ・コンポーネント | `ui/lib/`, `ui/components/`, `ui/styles/` | `ui/Ph3/01` |
+| 各ページ | `ui/app/{balances,categories,portfolio,rules}/` | `ui/Ph3/02〜05` |
+| Playwright e2e | `tests/e2e/` | `ui/Ph3/06` |
+
+### Phase3 の前提（Phase 1 / Phase 2 完了が必要）
+
+`worker/Ph1/01〜07` + `postgres/Ph1/01` + `worker/Ph2/01〜08` がすべて緑であること。**Phase 1 / 2 完了前に Phase 3 着手はしない**（クリティカルパス違反、データ枯渇でテスト無効化）。
+
+## 5. タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典（行範囲） | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| api/01 | Phase 3.1 Flask REST API | [`api/Ph3/01-flask-rest-api.md`](./api/Ph3/01-flask-rest-api.md) | §4.3 L309-319 | `feature/flask-rest-api` | 🔴 高 |
+| api/02 | Phase 3.3〜3.5 集計エンドポイント | [`api/Ph3/02-aggregation-endpoints.md`](./api/Ph3/02-aggregation-endpoints.md) | §4.3 L333-365 | `feature/api-aggregation-endpoints` | 🟡 中 |
+| api/03 | Phase 3.6 ルール dry-run | [`api/Ph3/03-rule-dry-run-endpoint.md`](./api/Ph3/03-rule-dry-run-endpoint.md) | §4.3 L367-377 | `feature/api-rule-dry-run` | 🟡 中 |
+| ui/01 | Phase 3.2 React Dashboard 雛形 | [`ui/Ph3/01-react-dashboard-scaffold.md`](./ui/Ph3/01-react-dashboard-scaffold.md) | §4.3 L321-331 | `feature/react-dashboard-scaffold` | 🔴 高 |
+| ui/02 | Phase 3.3 月次推移グラフ | [`ui/Ph3/02-monthly-trend-chart.md`](./ui/Ph3/02-monthly-trend-chart.md) | §4.3 L333-343 | `feature/monthly-trend-chart` | 🟡 中 |
+| ui/03 | Phase 3.4 カテゴリ別支出ビュー | [`ui/Ph3/03-category-spending-view.md`](./ui/Ph3/03-category-spending-view.md) | §4.3 L345-355 | `feature/category-spending-view` | 🟡 中 |
+| ui/04 | Phase 3.5 ポートフォリオ構成ビュー | [`ui/Ph3/04-portfolio-view.md`](./ui/Ph3/04-portfolio-view.md) | §4.3 L357-365 | `feature/portfolio-view` | 🟡 中 |
+| ui/05 | Phase 3.6 ルール編集UI | [`ui/Ph3/05-rule-editor-ui.md`](./ui/Ph3/05-rule-editor-ui.md) | §4.3 L367-377 | `feature/rule-editor-ui` | 🔴 高 |
+| ui/06 | Phase 3 完了条件 (d) Playwright e2e | [`ui/Ph3/06-e2e-playwright.md`](./ui/Ph3/06-e2e-playwright.md) | §3.3 完了条件 (d) | `feature/playwright-e2e` | 🟡 中 |
+
+## 6. 依存関係図
+
+```mermaid
+flowchart TD
+    Pre1["Phase 1 完了<br/>(取込CLI + 月次SQL)"]
+    Pre2["Phase 2 完了<br/>(自動取込でデータ蓄積)"]
+
+    A1["api/Ph3/01<br/>Flask REST API (3.1)"]
+    A2["api/Ph3/02<br/>集計エンドポイント (3.3-3.5補助)"]
+    A3["api/Ph3/03<br/>ルール dry-run (3.6補助)"]
+
+    U1["ui/Ph3/01<br/>React 雛形 (3.2)"]
+    U2["ui/Ph3/02<br/>月次推移 (3.3)"]
+    U3["ui/Ph3/03<br/>カテゴリ別 (3.4)"]
+    U4["ui/Ph3/04<br/>ポートフォリオ (3.5)"]
+    U5["ui/Ph3/05<br/>ルール編集UI (3.6)"]
+    U6["ui/Ph3/06<br/>Playwright e2e"]
+
+    Pre1 --> A1
+    Pre2 -.補強.-> A1
+    A1 --> A2
+    A1 --> A3
+    A1 --> U1
+    A2 --> U2
+    A2 --> U3
+    A2 --> U4
+    A3 --> U5
+    U1 --> U2
+    U1 --> U3
+    U1 --> U4
+    U1 --> U5
+    U2 --> U6
+    U3 --> U6
+    U4 --> U6
+    U5 --> U6
+
+    classDef critical stroke:#d33,stroke-width:3px;
+    class A1,U1,U6 critical;
+```
+
+## 7. 推奨実装順序（モードB: Claude単体サブエージェント協調）
+
+クリティカルパス: `Phase1/Phase2 完了 → api/Ph3/01 → ui/Ph3/01 → ui/Ph3/06`（最低 4 直列）。
+
+```
+1. api/Ph3/01 (Flask REST API + 認証 + OpenAPI)
+2. api/Ph3/02 ‖ api/Ph3/03           （Coder 2体並列可）
+3. ui/Ph3/01 (React雛形)              （api/01 完了で着手可、api/02・03 と並列も可）
+4. ui/Ph3/02 ‖ ui/Ph3/03 ‖ ui/Ph3/04  （Coder 3体並列可、要 api/02 + ui/01）
+5. ui/Ph3/05 (ルール編集UI)            （要 api/03 + ui/01）
+6. ui/Ph3/06 (Playwright e2e)         （ui/02-05 完了後）
+```
+
+## 8. 横断的な技術判断（Plannerによる確定）
+
+| # | 判断事項 | 採用 | 理由 |
+|---|---|---|---|
+| 1 | **Vite 移行 vs Next.js 維持** | **Next.js 14 維持** | Phase 0 の Dockerfile / standalone build / healthcheck / 既存テスト保護（`agent-rules/00-core-principles.md` §1）。原典の「Vite + TypeScript + React」は本質である「TypeScript + React」を採用、ビルド基盤は Next.js を継続。差分は `ui/Ph3/01` 内で実装方針として明記。 |
+| 2 | **状態管理** | `@tanstack/react-query` v5 | データ取得・キャッシュ・mutate の業界標準。Redux / Zustand は YAGNI。 |
+| 3 | **API クライアント型** | OpenAPI から `openapi-typescript` で機械生成 | 手書きは重複リスク。`api/Ph3/01` で `/api/openapi.json` を valid 保証。 |
+| 4 | **OpenAPI 生成（API 側）** | `flask-smorest` | pydantic v2 連携・自動 spec 生成・Swagger UI 同梱。`apispec` 単体は手書き spec 多。 |
+| 5 | **認証** | Caddy が `Tailscale-User-Login` ヘッダを後段に伝播、API はそれを必須化、dev は `KAKEIBO_API_AUTH_BYPASS=1` でバイパス | ADR-010 と整合。 |
+| 6 | **グラフライブラリ** | `recharts` | React ファースト・MIT・Server Component 互換。 |
+| 7 | **e2e 配置** | `tests/e2e/`（リポジトリルート、pytest 系と並列） | `agent-rules/11-testing-strategy.md` テスト階層と整合。 |
+| 8 | **ReDoS 対策** | サーバ側 `signal.SIGALRM` ベースのタイムアウト + パターン長制限 | `re2` Python バインディングは NAS ビルド負荷増。`signal` は Linux コンテナ前提で十分。 |
+| 9 | **ライブラリ追加先** | API 拡張は `pyproject.toml`、UI は `ui/package.json` | Phase 1〜2 と同じ慣習。 |
+| 10 | **CSS / フォント** | `tailwindcss` + デザイントークン、フォントは `Noto Sans JP` + 日本語ディスプレイフォント。**Inter / Roboto / system-ui を使用しない** | `agent-rules/15-frontend-design.md` の禁止事項を厳守。 |
+
+## 9. Phase3 完了条件カバレッジ
+
+| 完了条件 | 主担当 | 補強 |
+|---|---|---|
+| (a) Flask REST API CRUD | `api/Ph3/01` | `api/Ph3/02`, `api/Ph3/03` |
+| (b) 残高推移 / カテゴリ / 保有資産表示 | `ui/Ph3/02` / `03` / `04` | `api/Ph3/02` |
+| (c) UI からルール CRUD | `ui/Ph3/05` | `api/Ph3/01`, `api/Ph3/03` |
+| (d) Playwright e2e 主要シナリオ緑 | `ui/Ph3/06` | – |
+| (e) `tsc --strict` クリーン | 全 ui タスク横断 | – |
+
+## 10. 既知の課題・申し送り
+
+- **Phase 1 / 2 完了が必須前提**。未完了状態では `api/Ph3/01〜03` の統合テストが意味をなさない。
+- **リスク R-09（ReDoS）**: `api/Ph3/03` 内で `signal.SIGALRM` タイムアウト + パターン長制限で対応。
+- **リスク R-10（Tailscale Funnel）**: ADR-010 §結果で「Funnel 不使用」確定済み、Phase3 に影響なし。
+- **認証ヘッダ実機検証**は Phase 3 内では unit test レベルで完結、本番 Caddy 経路の検証は Phase 4.6 リリース時に実施。
+- **SQLAlchemy ORM 不採用**を Phase 3 でも継続（Phase 1 方針）。Phase 4 以降に再検討余地。
+- **Vite vs Next.js の原典差分**: 原典 §4.3 Phase 3.2 の文言「Vite + TypeScript + React」と本振り分けの実装方針（Next.js 維持）が異なる点について、`ui/Ph3/01` 内で実装方針として明示し、原典は不変扱い。気になる場合は ADR-013 候補として将来起票可能。
+
+## 11. Phase 4 への申し送り
+
+Phase 3 完了時点で API + UI が揃い、Phase 4「Polish」に着手可能。Phase 4 着手時に `docs/plans/{api,ui,worker}/Ph4/` を新設する。
+- `api/Ph3/03` の `categorizer/rules.py` を Phase 4.1 LLM 分類サービスで再利用
+- `ui/Ph3/05` のルール編集 UI を Phase 4.2 半自動学習へ拡張
+- Playwright e2e を Phase 4 のリグレッション一式に組み込み

--- a/docs/plans/api/Ph2/README.md
+++ b/docs/plans/api/Ph2/README.md
@@ -1,0 +1,55 @@
+---
+title: api サービス Phase2 タスク指示書
+service: api
+phase: 2
+status: NoTasks
+parent_index: docs/plans/12-phase2-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# api サービス Phase2 タスク指示書
+
+## 結論：Phase2 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `api` サービス（Flask + Werkzeug 開発サーバ）は Phase 0 で完了済み（`/health` のみ）。Phase 1 と同様、Phase 2 でも **新規エンドポイントを追加しない**。
+
+`docs/plans/01-development-plan.md` §4.2 のタスク 2.1〜2.8 はすべて `worker` サービス内部で完結する自動取込パイプラインで、外部から HTTP で叩く対象ではない。
+
+## サービス境界（参考）
+
+| 範囲 | Phase 2 での扱い |
+|---|---|
+| `/health` エンドポイント | 既存のまま維持（HEALTHCHECK / Caddy 疎通用） |
+| Phase 3 で追加予定の REST エンドポイント | 着手しない（Phase 3.1 で `feature/flask-rest-api`） |
+
+## Phase2 の間に api サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| `pyproject.toml` への runtime 依存追加（`watchdog`, `apscheduler`, `google-auth` 等） | 可（再ビルド必要） | `worker/Ph2/01,03,08` で発生。`api` イメージにも反映されるが API 機能は変わらない |
+| `src/kakeibo/__init__.py` の `__version__` 更新 | 可 | リリース時の同期 |
+| `src/kakeibo/config.py` 改修 | 慎重に | `Settings` 既存フィールド（`paypal_api_secret`, `gmail_oauth_token_path`）を **API 側が import しても壊れない** ことが必要 |
+| `api/Dockerfile` 変更 | 不要 | – |
+
+`agent-rules/00-core-principles.md` の3原則 §1 デグレッション防止と整合：既存の `/health` レスポンスや `pytest tests/unit/` を壊さないこと。
+
+## Phase 3.1 への申し送り
+
+Phase 3 で本サービスに本格着手するときの起点：
+
+- 原典: `docs/plans/01-development-plan.md` §4.3 Phase 3.1 Flask REST API
+- ブランチ: `feature/flask-rest-api`
+- Phase 2 で作成された `RawMail`, メールパーサ群, PayPal Adapter, Watcher が `src/kakeibo/` 配下に揃う想定なので、API は **既存ロジックを呼び出すだけ** の薄いレイヤとして実装可能になる
+- 想定エンドポイント: `GET /api/transactions`（Phase 2 で投入された取引も返却対象）
+
+Phase 3.1 着手時に `docs/plans/api/Ph3/01-flask-rest-api.md` を新設する。
+
+## 担当 Worker サブエージェント
+
+Phase2 期間中の起動は **Reviewer のみ**：
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `worker/Ph2/*` のタスクで `pyproject.toml` / `src/kakeibo/__init__.py` / `src/kakeibo/config.py` が変更された際、`api` コンテナのビルド・起動と既存テスト（`tests/unit/test_settings_repr.py` など）への影響をチェック |
+
+Coder / Planner / Git-composer の起動は Phase2 では原則不要。

--- a/docs/plans/api/Ph3/01-flask-rest-api.md
+++ b/docs/plans/api/Ph3/01-flask-rest-api.md
@@ -1,0 +1,243 @@
+---
+title: api/Ph3/01 Flask REST API
+service: api
+phase_task_id: 3.1
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.1（行 309-319）
+branch: feature/flask-rest-api
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# api/Ph3/01 Flask REST API（Phase 3.1）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.3 Phase 3.1 を `api` サービス担当の指示書として展開。Phase3 完了条件 (a)「Flask REST API が CRUD を提供する」を直接満たす。Phase 3 の **クリティカルパス起点**。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`compose.yml` `api` サービス（Flask + Werkzeug、`api/Dockerfile` の uv マルチステージ）。Phase 0 の `/health` のみのスタブを **本格的な REST API** に拡張する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph1/05`（取込CLI 完了 → DB に取引データがある） + `postgres/Ph1/01`（スキーマ確定） |
+| 下流 | `api/Ph3/02`（集計）, `api/Ph3/03`（dry-run）, `ui/Ph3/01`〜`05` |
+
+Phase 2 完了は望ましいが必須ではない（Phase 1.6 で投入された CSV だけでもテストデータとしては成立）。
+
+## 入力（Coder が読むべきファイル）
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.1（行 309-319）
+2. **デプロイ**: `docs/design/04-deployment-stack.md` §3 / §6（Caddy + api 経路）
+3. **セキュリティ**: `docs/design/05-security-model.md` §11（Tailscale 認証）, §10.2（`raw_payload` の扱い）
+4. **ADR**: `docs/adr/009-nas-docker-compose.md`, `docs/adr/010-tailscale-only-access.md`
+5. **既存 API**: `src/kakeibo/api/{app.py, __main__.py, __init__.py}`, `api/Dockerfile`
+6. **設定ローダー**: `src/kakeibo/config.py`（`KAKEIBO_API_AUTH_BYPASS` フィールド追加先）
+7. **ドメイン型**: `src/kakeibo/domain/`（Phase 1.2 で実装される `Transaction` / `Holding` / `BalanceSnapshot`）
+8. **既存テスト**: `tests/unit/test_settings_repr.py`（破壊しないこと）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `pyproject.toml` | `flask-smorest>=0.44,<1`, `marshmallow>=3.21,<4` を `[project.dependencies]` に追加 |
+| `src/kakeibo/config.py` | `auth_bypass: bool = False`（`KAKEIBO_API_AUTH_BYPASS` で上書き）追加 |
+| `src/kakeibo/api/app.py` | ファクトリで Blueprint / 認証 / エラー / OpenAPI を登録 |
+| `src/kakeibo/api/auth.py` | `Tailscale-User-Login` ヘッダ検証 + dev バイパス |
+| `src/kakeibo/api/errors.py` | 共通エラーハンドラ（4xx / 5xx の JSON 化） |
+| `src/kakeibo/api/openapi.py` | flask-smorest の `Api` インスタンス生成 + `/api/openapi.json` + Swagger UI |
+| `src/kakeibo/api/blueprints/__init__.py` | Blueprint 集約 |
+| `src/kakeibo/api/blueprints/balances.py` | `GET /api/balances`（口座別最新残高） |
+| `src/kakeibo/api/blueprints/transactions.py` | `GET /api/transactions`（ページネーション + フィルタ） |
+| `src/kakeibo/api/blueprints/categories.py` | `GET/POST/PUT/DELETE /api/categories` |
+| `src/kakeibo/api/blueprints/rules.py` | `GET/POST/PUT/DELETE /api/rules`（dry-run は `api/Ph3/03` で追加） |
+| `src/kakeibo/api/schemas/__init__.py` | スキーマ集約 |
+| `src/kakeibo/api/schemas/{balance,transaction,category,rule,common}.py` | pydantic v2 モデル |
+| `src/kakeibo/db/repositories/__init__.py` | リポジトリ基底 |
+| `src/kakeibo/db/repositories/{balances,transactions,categories,rules}.py` | psycopg ベースの薄いラッパ |
+| `tests/unit/api/__init__.py` | 新規 |
+| `tests/unit/api/conftest.py` | Flask test client + 認証バイパス fixture |
+| `tests/unit/api/test_{balances,transactions,categories,rules,auth,openapi}.py` | エンドポイント契約テスト |
+| `tests/integration/api/__init__.py` | 新規 |
+| `tests/integration/api/test_crud_e2e.py` | testcontainers Postgres + フィクスチャ投入で CRUD 統合確認 |
+
+## 実装方針
+
+### 1. OpenAPI 生成: `flask-smorest` 採用
+
+- `flask-smorest` は pydantic v2 と直接連携し、`@blp.arguments` / `@blp.response` デコレータで自動的にスキーマ・ドキュメントが生成される
+- `apispec` 単体や `flask-pydantic-spec` は手書き spec が増える / 活発さが低いため不採用
+- `marshmallow` は flask-smorest が依存として要求するため `[project.dependencies]` に明示
+
+### 2. 認証: Caddy + `Tailscale-User-Login` ヘッダ前提
+
+- 本番では Caddy が `tsidp` でユーザを認証し `Tailscale-User-Login` ヘッダを後段の Flask に伝播（`docs/design/05-security-model.md` §11）
+- API ミドルウェアは **ヘッダの存在確認のみ**（実際の認可は Tailscale が担当）
+- 開発環境では `Settings.auth_bypass=True`（環境変数 `KAKEIBO_API_AUTH_BYPASS=1`）でミドルウェアをスキップ
+- **本番ビルドで誤って bypass が有効化されない** ことを `tests/unit/api/test_auth.py` で検証（既定値 `False`、Settings.__repr__ でマスクなしで露出）
+
+### 3. 永続化層: psycopg + 薄いリポジトリ関数
+
+- SQLAlchemy ORM は **不採用**（Phase 1 方針継承）
+- 各リポジトリ関数は `def list_transactions(conn: psycopg.Connection, *, from_date: date, ...) -> list[TransactionDTO]` の形式
+- パラメータ化クエリ（`%s` プレースホルダ）で SQL インジェクション対策
+- 接続管理は Flask の `g` オブジェクト + `@app.teardown_appcontext` で行う（リクエスト単位の接続/解放）
+
+### 4. エラー応答 DTO
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request",
+    "details": {"field": "name", "reason": "required"}
+  }
+}
+```
+
+### 5. CORS 不採用
+
+- Caddy が `/` → ui:3000、`/api/*` → api:8000 を **同一オリジン**で配信するため CORS は不要（YAGNI）
+- 本番想定では Tailscale 配下の単一ホスト名で UI と API がアクセスされる
+
+### 6. レスポンスから `raw_payload` を除外
+
+- `transactions.raw_payload` JSONB は EC 注文番号や PayPal メタデータを含むため、API レスポンスでは **省略**
+- `TransactionResponse` スキーマで明示的に未含
+
+### 7. ページネーション規約
+
+- `?page=1&limit=50`（既定 `limit=100`、上限 `limit=1000`）
+- レスポンスメタ: `{data: [...], meta: {total: N, page: 1, limit: 50, has_next: bool}}`
+
+### 8. 日付・通貨
+
+- 日付返却は `YYYY-MM-DD`（タイムゾーンなし、Asia/Tokyo 想定）
+- 金額は `Decimal` を `string` でシリアライズ（`float` 経由による精度損失防止）
+- 通貨コードは ISO 4217 3 文字大文字
+
+## 実装手順（TDD: Red → Green → Refactor）
+
+### 0. ブランチ作成
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b feature/flask-rest-api
+```
+
+### 1. Red: テストを先に書く
+
+`tests/unit/api/conftest.py` で Flask test client + auth bypass fixture を用意。各エンドポイントに以下を記述：
+
+- `test_get_transactions_returns_paginated_list()`：50 件以下、`{data, meta: {total,page,limit}}` 構造
+- `test_get_transactions_filters_by_date_range()`：`?from=&to=` でフィルタ
+- `test_get_transactions_excludes_raw_payload()`：レスポンスに `raw_payload` キー無し
+- `test_post_categories_validates_required_fields()`：`name` 欠落で 422
+- `test_put_rule_priority_persists_change()`
+- `test_delete_rule_removes_persisted_row()`
+- `test_unauthorized_when_tailscale_header_missing()`：401 + エラー DTO
+- `test_dev_bypass_allows_anonymous_access()`：`KAKEIBO_API_AUTH_BYPASS=1` で 200
+- `test_settings_auth_bypass_default_is_false()`：本番安全性確認
+- `test_openapi_endpoint_returns_valid_spec()`：`paths` / `components.schemas` を含む
+
+`tests/integration/api/test_crud_e2e.py` で testcontainers + `worker/Ph1/05` の取込CLIフィクスチャを使い、`POST /api/categories` → `GET` で永続化確認。
+
+`pytest tests/unit/api/ tests/integration/api/` で全件赤を確認。
+
+### 2. Green: 最小実装で順に通す
+
+1. `pyproject.toml` に `flask-smorest`, `marshmallow` 追加 → `uv sync`
+2. `src/kakeibo/config.py` に `auth_bypass` 追加（既存テストを破壊しないよう既定値 `False`、`__repr__` のマスク非対象）
+3. `src/kakeibo/api/openapi.py` で `flask_smorest.Api` インスタンス生成
+4. `src/kakeibo/api/auth.py` で `before_request` ハンドラを実装（bypass フラグ読み取り）
+5. `src/kakeibo/api/errors.py` で `errorhandler(HTTPException)` を実装
+6. `src/kakeibo/api/schemas/*.py` を pydantic v2 で実装
+7. `src/kakeibo/db/repositories/*.py` を実装
+8. `src/kakeibo/api/blueprints/*.py` を実装（balances → transactions → categories → rules の順）
+9. `src/kakeibo/api/app.py` のファクトリで全部を登録
+
+### 3. Refactor
+
+- 重複するエラー DTO 生成を `errors.make_error_response(code, message, details=None, status=400)` に集約
+- リポジトリ共通の接続取得を `_get_conn()` に抽出
+- pydantic スキーマの `Config` 共通化
+
+## 受入条件
+
+原典 §4.3 Phase 3.1 の受入基準に加えて：
+
+- `GET /api/balances`, `GET /api/transactions`, `GET/POST/PUT/DELETE /api/categories`, `GET/POST/PUT/DELETE /api/rules` がすべて動作
+- OpenAPI スキーマが `/api/openapi.json` から取得でき、Swagger UI が `/api/docs`（または `/api/swagger`）で表示される
+- 認証は Tailscale ヘッダ前提で localhost / Tailnet からのみ受理
+- `pytest` + Flask test client で全エンドポイント緑
+- `KAKEIBO_API_AUTH_BYPASS` の既定値が `False`（本番安全性）
+- レスポンスに `transactions.raw_payload` が含まれない
+- ページネーション既定 `limit=100`、上限 `limit=1000` を超えるリクエストで 422
+- `pyright` クリーン、`ruff` 違反ゼロ
+- 既存テスト（`tests/unit/test_settings_repr.py` 等）が緑のまま
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/api/ tests/integration/api/
+pytest tests/unit/test_settings_repr.py  # 既存破壊チェック
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/flask-rest-api`
+- コミット粒度（最低 7 件、`agent-rules/10-git-strategy.md` 準拠）：
+  1. `テスト: REST APIのCRUD・認証・OpenAPIエンドポイントのテストを先行作成`
+  2. `設定: flask-smorestとmarshmallowをruntime依存に追加`
+  3. `機能: Settings.auth_bypassフィールドを追加（本番既定False）`
+  4. `機能: APIスキーマ（pydantic v2モデル）と共通エラーハンドラを実装`
+  5. `機能: Tailscaleヘッダ前提の認証ミドルウェアを実装（devバイパス付き）`
+  6. `機能: psycopgベースのリポジトリ層（balances/transactions/categories/rules）を実装`
+  7. `機能: balances/transactions/categories/rulesのBlueprintを実装`
+  8. `機能: OpenAPIスキーマ生成とSwagger UI公開を有効化`
+  9. `機能: app factoryに全Blueprint・認証・エラーハンドラ・OpenAPIを登録`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.1 Flask REST API を実装。
+
+## 成果物
+- pyproject.toml（flask-smorest, marshmallow 追加）
+- src/kakeibo/api/{app.py, auth.py, errors.py, openapi.py}
+- src/kakeibo/api/blueprints/{balances,transactions,categories,rules}.py
+- src/kakeibo/api/schemas/{balance,transaction,category,rule,common}.py
+- src/kakeibo/db/repositories/{balances,transactions,categories,rules}.py
+- src/kakeibo/config.py（auth_bypass 追加）
+- tests/unit/api/* / tests/integration/api/*
+
+## 検証結果
+- pytest（unit + integration）: 全件緑
+- /api/openapi.json valid
+- 認証バイパス既定 False / Tailscale ヘッダ無しで 401
+- pyright / ruff: クリーン
+- 既存テスト破壊なし
+
+## 次のアクション提案
+api/Ph3/02 (集計) と api/Ph3/03 (dry-run) を 2 並列で着手可能。
+ui/Ph3/01 (React雛形) も並行着手可能。
+```
+
+## 注意事項
+
+- **既存テストを破壊しない**（`agent-rules/00-core-principles.md` §1）。`tests/unit/test_settings_repr.py` で `auth_bypass` フィールド追加時の挙動を要確認。
+- **`auth_bypass` の本番誤有効化**を防ぐ：`Settings` のデフォルト値を `False`、テストで既定値を明示検証。`__repr__` ではマスクしない（運用診断のため可視化）。
+- **`raw_payload` を絶対に返さない**：TransactionResponse スキーマで明示除外し、テストで non-existence を検証。
+- **Tailscale 認証実機テストは Phase 4.6** で実施。Phase 3 では unit test レベルでミドルウェア挙動のみ検証。
+- **CORS は実装しない**（YAGNI、同一オリジン）。
+- 集計エンドポイント（`/api/balances/monthly` 等）は本タスクでは扱わず `api/Ph3/02` で実装。
+- ルール dry-run（`POST /api/rules/dry-run`）は本タスクでは扱わず `api/Ph3/03` で実装。
+- SQLAlchemy ORM は **使わない**（Phase 1 方針継続）。psycopg のパラメータ化クエリで安全性担保。

--- a/docs/plans/api/Ph3/02-aggregation-endpoints.md
+++ b/docs/plans/api/Ph3/02-aggregation-endpoints.md
@@ -1,0 +1,221 @@
+---
+title: api/Ph3/02 集計エンドポイント（残高推移・カテゴリ別支出・ポートフォリオ）
+service: api
+phase_task_id: 3.3-aux,3.4-aux,3.5-aux
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.3〜3.5（行 333-365）
+branch: feature/api-aggregation-endpoints
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# api/Ph3/02 集計エンドポイント（Phase 3.3〜3.5 補助）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.3 / 3.4 / 3.5 の **API 側補助タスク**。原典 3.1 の受入基準は CRUD 止まりで集計 API は明示されていないため、3.3〜3.5（UI 側のグラフ系）が必要とする集計エンドポイントを Planner 判断で本タスクに分離した。
+
+## 担当サービス
+
+`compose.yml` `api` サービス。`api/Ph3/01` で構築した Blueprint 基盤に **集計専用の Blueprint** を追加し、Phase 1.8 の月次サマリ SQL を再利用 + 拡張する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `api/Ph3/01`（REST API 基盤）+ `worker/Ph1/07`（月次サマリ SQL）+ Phase 1〜2 の `holdings` / `balance_snapshots` 投入 |
+| 下流 | `ui/Ph3/02`（月次推移）, `ui/Ph3/03`（カテゴリ別）, `ui/Ph3/04`（ポートフォリオ） |
+
+`api/Ph3/03` と並列着手可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.3 / 3.4 / 3.5（行 333-365）
+2. **データモデル**: `postgres/docs/design/01-data-model.md`（`balance_snapshots`, `holdings`, `transactions`, `categories`）
+3. **分類エンジン**: `worker/docs/design/03-categorization-engine.md` §6（`category_source` フィルタ）
+4. **既存資産**: `sql/queries/monthly_summary.sql`（Phase 1.8 で実装される月次サマリ）
+5. **API 基盤**: `api/Ph3/01-flask-rest-api.md` で実装される `flask-smorest` 連携、リポジトリ層パターン
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `sql/queries/monthly_balance_trend.sql` | 全口座合計残高の月次推移 |
+| `sql/queries/category_spending.sql` | 月別カテゴリ別支出（親→子ドリルダウン対応） |
+| `sql/queries/portfolio_composition.sql` | `holdings.symbol_kind` 別構成比 + 直近スナップショット日付 |
+| `src/kakeibo/api/schemas/aggregations.py` | レスポンスモデル（`MonthlyBalance`, `CategorySpending`, `PortfolioComposition`） |
+| `src/kakeibo/api/blueprints/aggregations.py` | `GET /api/balances/monthly`, `GET /api/categories/spending`, `GET /api/holdings/composition` |
+| `src/kakeibo/db/repositories/aggregations.py` | 上記 SQL を psycopg で呼ぶ薄いラッパ |
+| `src/kakeibo/api/app.py` | aggregations Blueprint を登録（既存ファクトリへ追記） |
+| `tests/integration/api/test_aggregations.py` | testcontainers + 決定的フィクスチャで集計値の正当性検証 |
+| `tests/unit/api/test_aggregations_validation.py` | クエリパラメータバリデーション |
+
+## 実装方針
+
+### 1. 集計は SQL 側で行う
+
+- API 層で Python 集計しない。理由：取引数が増えても性能を保つ + Phase 1.8 と整合。
+- 各 SQL は `:from`, `:to` パラメータで期間指定（半開区間 `[from, to)`）。
+
+### 2. 月次残高推移 (`/api/balances/monthly`)
+
+```sql
+-- monthly_balance_trend.sql（概略）
+WITH monthly_snapshots AS (
+    SELECT
+        date_trunc('month', as_of_date)::date AS month,
+        account_id,
+        balance,
+        ROW_NUMBER() OVER (PARTITION BY account_id, date_trunc('month', as_of_date) ORDER BY as_of_date DESC) AS rn
+    FROM balance_snapshots
+    WHERE as_of_date >= :date_from AND as_of_date < :date_to
+)
+SELECT
+    month,
+    SUM(balance) AS total_balance
+FROM monthly_snapshots
+WHERE rn = 1
+GROUP BY month
+ORDER BY month;
+```
+
+- 既定: 直近 12 か月（`from = today - 12 months`、`to = today + 1 day`）
+- レスポンス: `{data: [{month: "2026-04", total_balance: "1234567.00"}, ...]}`
+
+### 3. カテゴリ別支出 (`/api/categories/spending`)
+
+- 親カテゴリで集計 + `?parent_id=X` で子カテゴリへドリルダウン
+- 未分類取引（`category_id IS NULL`）は `null_category` キーで明示返却（**「未分類」のローカライズは UI 側の責務**）
+- レスポンス例:
+  ```json
+  {
+    "month": "2026-04",
+    "categories": [
+      {"id": 1, "name": "食費", "amount": "23000.00", "parent_id": null, "has_children": true},
+      {"id": null, "name": null, "amount": "5000.00", "parent_id": null, "has_children": false}
+    ]
+  }
+  ```
+
+### 4. ポートフォリオ構成 (`/api/holdings/composition`)
+
+- `symbol_kind` 別の評価額合計と構成比を計算
+- 評価額 NULL の銘柄は別配列 `warnings` に列挙（原典 §4.3 Phase 3.5 受入基準と整合）
+- `snapshot_date`（直近スナップショット日付）を併せて返却
+- レスポンス例:
+  ```json
+  {
+    "snapshot_date": "2026-04-30",
+    "composition": [
+      {"symbol_kind": "stock_jp", "total_value": "500000.00", "ratio": 0.4},
+      {"symbol_kind": "fund", "total_value": "750000.00", "ratio": 0.6}
+    ],
+    "warnings": [
+      {"symbol": "XXXX", "symbol_kind": "stock_us", "last_seen": "2026-03-15"}
+    ]
+  }
+  ```
+
+### 5. クエリパラメータバリデーション
+
+- 全エンドポイントで `?from=YYYY-MM-DD&to=YYYY-MM-DD` を受理（月単位の場合は `from=YYYY-MM-01`）
+- 未指定時は既定値（直近 12 か月 / 当月）
+- 不正な日付フォーマット → 422
+
+### 6. 認証
+
+- `api/Ph3/01` の認証ミドルウェアを継承（個別実装不要）
+
+### 7. 空データ時
+
+- `200 + {data: []}` または `{categories: []}` を返す（404 は採用しない、UI の空状態表示と整合）
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/api/test_aggregations_validation.py` でクエリパラメータバリデーション
+- `tests/integration/api/test_aggregations.py` で testcontainers + フィクスチャ：
+  - `test_monthly_balance_trend_returns_12_months_by_default()`
+  - `test_monthly_balance_trend_with_custom_range()`
+  - `test_category_spending_drilldown_includes_subcategories()`
+  - `test_category_spending_marks_uncategorized()`（`null_category` キーで返却）
+  - `test_portfolio_composition_separates_null_value_holdings()`
+  - `test_aggregations_return_empty_data_when_no_records()`
+  - `test_aggregations_require_auth()`
+
+### 2. Green
+
+1. `sql/queries/monthly_balance_trend.sql` を実装
+2. `sql/queries/category_spending.sql` を実装
+3. `sql/queries/portfolio_composition.sql` を実装
+4. `src/kakeibo/db/repositories/aggregations.py` を実装
+5. `src/kakeibo/api/schemas/aggregations.py` を実装
+6. `src/kakeibo/api/blueprints/aggregations.py` を実装
+7. `app.py` ファクトリに Blueprint 登録
+
+### 3. Refactor
+
+- 期間パラメータの解釈ロジックを `_parse_date_range(from_str, to_str, default_months=12)` に抽出
+- SQL ファイル読込ヘルパは Phase 1.8 の `src/kakeibo/sql/runner.py` を再利用
+
+## 受入条件
+
+- 同一データセットを SQL 直接実行と API 経由で取得した値が完全一致
+- 空データ時に `200 + {data: []}` を返す（404 ではない）
+- レスポンス時間が pytest 計測で 1 リクエストあたり 200ms 以内（家庭内データ規模前提）
+- 全エンドポイントで認証必須（`api/Ph3/01` のミドルウェア継承）
+- OpenAPI スキーマに集計エンドポイントが反映される
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/integration/api/test_aggregations.py tests/unit/api/test_aggregations_validation.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/api-aggregation-endpoints`
+- コミット粒度（最低 5 件）：
+  1. `テスト: 集計エンドポイント（残高推移・カテゴリ別支出・ポートフォリオ）のテストを先行作成`
+  2. `機能: 月次残高推移SQLとリポジトリを追加`
+  3. `機能: カテゴリ別支出SQLとドリルダウン対応リポジトリを追加`
+  4. `機能: ポートフォリオ構成SQLとNULL評価額警告ロジックを追加`
+  5. `機能: aggregations BlueprintをOpenAPIに登録`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.3〜3.5 集計エンドポイントを実装。
+
+## 成果物
+- sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql
+- src/kakeibo/api/blueprints/aggregations.py
+- src/kakeibo/api/schemas/aggregations.py
+- src/kakeibo/db/repositories/aggregations.py
+- tests/integration/api/test_aggregations.py
+- tests/unit/api/test_aggregations_validation.py
+
+## 検証結果
+- pytest 全件緑
+- レスポンス時間 < 200ms
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+ui/Ph3/02 / 03 / 04 が 3 並列で着手可能。
+```
+
+## 注意事項
+
+- **未分類カテゴリ**: API は `null_category` キーで返し、表示文言（「未分類」「その他」など）は UI 側で決定。
+- **金額は文字列**で返却（`Decimal` 精度保持）。UI 側で `Intl.NumberFormat` で整形。
+- **タイムゾーン**: 期間境界はローカル日付（Asia/Tokyo）として扱う。SQL 内の `date_trunc` も Asia/Tokyo 想定。
+- **`category_source` フィルタ**: 集計対象は全 `category_source`（`rule`, `llm`, `manual`, `NULL`）を含む。Phase 4 で「LLM 分類のみ除外」のような切替を入れる場合は別パラメータで追加。
+- **ポートフォリオ snapshot_date**: 全口座の最新 snapshot_date を集約してレスポンス。各口座でズレがある場合は最も古いものを返す（保守的）。
+- **インデックス追加は本タスクでは行わない**（実データで遅延が顕在化したら別タスクで追加、原典 §スコープ「含まない」と整合）。

--- a/docs/plans/api/Ph3/03-rule-dry-run-endpoint.md
+++ b/docs/plans/api/Ph3/03-rule-dry-run-endpoint.md
@@ -1,0 +1,214 @@
+---
+title: api/Ph3/03 ルール dry-run エンドポイント
+service: api
+phase_task_id: 3.6-aux
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.6（行 367-377）
+branch: feature/api-rule-dry-run
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# api/Ph3/03 ルール dry-run エンドポイント（Phase 3.6 補助）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.6 の **API 側補助タスク**。受入基準 (c)「既存取引へのプレビュー（このルールならN件マッチ）が表示される」を実現するための `POST /api/rules/dry-run` エンドポイントと、Categorizer の Rule マッチロジックを実装する。リスク R-09（ReDoS）対応も本タスクの範囲。
+
+## 担当サービス
+
+`compose.yml` `api` サービス。`api/Ph3/01` のルール CRUD を拡張する形で dry-run を追加し、`design/03-categorization-engine.md` の Rule マッチロジックを `src/kakeibo/categorizer/` 配下に実装ファイル化する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `api/Ph3/01`（Rule CRUD と認証）+ Phase 1 の `transactions` 投入 |
+| 下流 | `ui/Ph3/05`（ルール編集UI のプレビュー機能） |
+
+`api/Ph3/02` と並列着手可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.6（行 367-377）
+2. **ADR**: `docs/adr/008-three-tier-categorization.md`
+3. **分類エンジン設計**: `worker/docs/design/03-categorization-engine.md` §3
+4. **Phase 1.7 ハッシュ境界条件**: `worker/Ph1/06-hash-idempotency-tests.md`（description 正規化方針）
+5. **リスク**: `docs/plans/01-development-plan.md` §9 R-09（ReDoS）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/categorizer/__init__.py` | 新規パッケージ |
+| `src/kakeibo/categorizer/rules.py` | `match_rule(rule, transaction) -> bool` の実装 |
+| `src/kakeibo/categorizer/safe_regex.py` | regex タイムアウト保護 |
+| `src/kakeibo/api/blueprints/rules.py` | 既存に `POST /api/rules/dry-run` を追加 |
+| `src/kakeibo/api/schemas/rule.py` | `DryRunRequest`, `DryRunResponse` を追加（既存に追記） |
+| `src/kakeibo/db/repositories/rules.py` | 既存に `match_transactions(...)` を追加 |
+| `tests/unit/categorizer/__init__.py` | 新規 |
+| `tests/unit/categorizer/test_rules.py` | match_type 別の単体テスト（regex / contains / exact） |
+| `tests/unit/categorizer/test_safe_regex.py` | ReDoS パターンでのタイムアウト検証 |
+| `tests/unit/api/test_rule_dry_run.py` | エンドポイント契約 + 件数算出 |
+
+## 実装方針
+
+### 1. ReDoS 対策: SIGALRM タイムアウト + パターン長制限
+
+- **`re2` 採用しない**：Python バインディング（`google-re2`）はビルド負荷が NAS 上で重い、メンテナンス活発さも限定的
+- 代わりに **`signal.SIGALRM` ベースのタイムアウト 500ms** + **パターン長 500 文字制限** で防御
+- パターン長超過は 422 で即時拒否
+- SIGALRM はメインスレッドからの呼び出しが必要だが、Flask + Werkzeug 単一スレッド構成では問題なし（`gevent`/`gunicorn worker_class` を使う場合は別途 ADR で再評価）
+
+### 2. dry-run リクエスト/レスポンス
+
+```
+POST /api/rules/dry-run
+Content-Type: application/json
+
+{
+  "match_field": "description",   # 現状 description のみ、将来 amount / source も
+  "match_type": "regex",          # regex | contains | exact
+  "pattern": "コンビニ"
+}
+
+→ 200 OK
+{
+  "matched_count": 12,
+  "sample": [
+    {"transaction_id": 123, "description": "コンビニATM 引出", "occurred_on": "2026-04-15"},
+    ... (最大10件)
+  ]
+}
+```
+
+### 3. マッチ対象の絞り込み
+
+- `category_source IN ('rule', NULL)` のみ対象（`design/03-categorization-engine.md` §6 と整合：`manual` / `llm` を上書きしない）
+- 現行 `category_id IS NULL` の取引も含む（未分類のうちこのルールでマッチするものをプレビュー）
+
+### 4. 本番 INSERT を伴わない（dry-run）
+
+- DB 書き込みなし（読み取り専用）
+- 認証は通常通り必須（ルール構造を漏らさない）
+
+### 5. Phase 4 への布石
+
+- `match_rule()` の API は Phase 4.1 LLM 分類サービス、Phase 4.2 半自動学習でも再利用される設計
+- 純粋関数（副作用なし）で実装し、テスト容易性を最優先
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/categorizer/test_safe_regex.py`：
+  - `test_safe_regex_match_normal_pattern_succeeds()`
+  - `test_safe_regex_redos_pattern_times_out()`：`(a+)+$` + 30 文字超の `a` 列で `TimeoutError`、テスト全体は 1 秒以内に完了
+  - `test_safe_regex_pattern_length_exceeded()`：500 文字超で `ValueError`
+- `tests/unit/categorizer/test_rules.py`：
+  - `test_match_type_regex_matches_pattern()`
+  - `test_match_type_contains_substring()`
+  - `test_match_type_exact_full_match()`
+  - `test_match_type_invalid_raises_value_error()`
+- `tests/unit/api/test_rule_dry_run.py`：
+  - `test_dry_run_returns_zero_for_no_match_pattern()`
+  - `test_dry_run_returns_sample_with_at_most_10_transactions()`
+  - `test_dry_run_rejects_invalid_match_type()`（422）
+  - `test_dry_run_redos_pattern_times_out_safely()`（API が 1 秒以内に 422 で応答）
+  - `test_dry_run_pattern_too_long_returns_422()`
+  - `test_dry_run_excludes_manual_categorized_transactions()`
+  - `test_dry_run_requires_auth()`
+
+### 2. Green
+
+1. `src/kakeibo/categorizer/safe_regex.py` を実装：
+   ```python
+   def safe_regex_match(pattern: str, text: str, *, timeout_ms: int = 500) -> bool:
+       if len(pattern) > 500:
+           raise ValueError("pattern too long")
+       def handler(signum, frame):
+           raise TimeoutError("regex timeout")
+       signal.signal(signal.SIGALRM, handler)
+       signal.setitimer(signal.ITIMER_REAL, timeout_ms / 1000)
+       try:
+           return bool(re.search(pattern, text))
+       finally:
+           signal.setitimer(signal.ITIMER_REAL, 0)
+   ```
+2. `src/kakeibo/categorizer/rules.py` で `match_rule(rule, transaction) -> bool` を実装
+3. `src/kakeibo/db/repositories/rules.py` に `match_transactions(conn, *, match_field, match_type, pattern, limit=10)` を追加
+4. `src/kakeibo/api/schemas/rule.py` に `DryRunRequest`, `DryRunResponse` を追加
+5. `src/kakeibo/api/blueprints/rules.py` に `POST /api/rules/dry-run` を追加
+
+### 3. Refactor
+
+- `safe_regex.py` のタイムアウトロジックを context manager `_alarm_timeout(ms)` に抽出
+- `rules.py` の match_type ディスパッチを辞書ベースに（早すぎる抽象化は避ける、3 種なら if/elif でも可）
+
+## 受入条件
+
+原典 §4.3 Phase 3.6 受入基準のうち API 側に関するもの：
+
+- バックエンドの dry-run エンドポイントを利用して **既存取引へのプレビュー（N件マッチ）** が取得できる
+- regex / contains / exact のいずれかの match_type に対応
+
+加えて：
+- ReDoS パターンで API がハングしない（pytest で 1 秒以内に 422 が返る）
+- パターン長 500 文字超は 422
+- dry-run の集計結果と、実ルール保存後のマッチング結果が一致（`match_rule` が両方で使われる）
+- 認可なしで 401（dry-run も書き込みは無いがルール構造を漏らさない）
+- OpenAPI スキーマに dry-run エンドポイントが反映される
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/categorizer/ tests/unit/api/test_rule_dry_run.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/api-rule-dry-run`
+- コミット粒度（最低 4 件）：
+  1. `テスト: ルールdry-run・マッチング・ReDoS耐性のテストを先行作成`
+  2. `機能: 正規表現のタイムアウト保護helperを実装`
+  3. `機能: design/03準拠のRuleマッチロジックを実装`
+  4. `機能: POST /api/rules/dry-runエンドポイントとリポジトリ拡張を追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.6 ルール dry-run エンドポイントとCategorizerコアを実装。
+
+## 成果物
+- src/kakeibo/categorizer/{rules,safe_regex}.py
+- src/kakeibo/api/blueprints/rules.py（dry-run 追加）
+- src/kakeibo/api/schemas/rule.py（DryRunRequest/Response 追加）
+- src/kakeibo/db/repositories/rules.py（match_transactions 追加）
+- tests/unit/categorizer/* / tests/unit/api/test_rule_dry_run.py
+
+## 検証結果
+- pytest 全件緑（< 1 秒で完了、ReDoS テスト含む）
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+- gevent / gunicorn worker_class 採用時は SIGALRM が機能しない可能性あり、ADR で再評価。
+- match_field は description のみ。amount / source 等は Phase 4 で拡張可能。
+
+## 次のアクション提案
+ui/Ph3/05 (ルール編集UI) の dry-run プレビュー機能で本エンドポイントを使用。
+```
+
+## 注意事項
+
+- **`signal.SIGALRM` は Unix 専用**。本プロジェクトは Linux コンテナ前提（Phase 0 の Dockerfile）のため許容、Windows 開発時の動作は保証しない。
+- **`re.search` のタイムアウト解像度** は OS の `setitimer` 解像度に依存（通常 10ms 単位）、500ms タイムアウトの実測ばらつきは許容。
+- **マルチスレッド/マルチプロセス Flask** に変更する場合は `signal` ではなく `multiprocessing.Process` ベースの隔離タイムアウトに変更が必要。Phase 3 の Werkzeug 単一スレッド前提で本実装は妥当、設定変更時は再評価。
+- **パターン長 500 文字** は経験的閾値。運用で短すぎ / 長すぎが顕在化したら ADR で再評価。
+- **`description` 正規化との整合**: `worker/Ph1/06`（ハッシュ境界条件 PBT）で確定された description 正規化方針（前後空白を strip しない）と本タスクの match ロジックが整合していること。
+- **Phase 4.2 半自動学習** で本ロジックを再利用するため、`match_rule(rule, transaction) -> bool` のシグネチャを安易に変えない。

--- a/docs/plans/api/Ph3/README.md
+++ b/docs/plans/api/Ph3/README.md
@@ -1,0 +1,100 @@
+---
+title: api サービス Phase3 タスク指示書
+service: api
+phase: 3
+status: Ready
+parent_index: docs/plans/13-phase3-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# api サービス Phase3 タスク指示書
+
+`compose.yml` `api` サービス（Flask + Werkzeug 開発サーバ）は Phase 0 で `/health` のみのスタブが配備済み。Phase 3 で **REST API の本体実装**に着手する。
+
+## サービス境界（Phase3 で本ディレクトリが扱うもの）
+
+| 範囲 | パス |
+|---|---|
+| Flask アプリファクトリ拡張 | `src/kakeibo/api/app.py`（既存ファクトリに Blueprint / 認証 / OpenAPI を登録） |
+| REST Blueprint 群 | `src/kakeibo/api/blueprints/{balances,transactions,categories,rules,aggregations}.py` |
+| pydantic v2 リクエスト/レスポンスモデル | `src/kakeibo/api/schemas/` |
+| 認証ミドルウェア（Tailscale ヘッダ） | `src/kakeibo/api/auth.py` |
+| 共通エラーハンドラ | `src/kakeibo/api/errors.py` |
+| OpenAPI 自動生成 | `src/kakeibo/api/openapi.py` |
+| リポジトリ層（psycopg ベース、ORM 不採用） | `src/kakeibo/db/repositories/` |
+| Categorizer（dry-run 用ロジック） | `src/kakeibo/categorizer/` |
+| 集計 SQL（Phase 1.8 に追加） | `sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql` |
+| API 関連テスト | `tests/unit/api/`, `tests/integration/api/`, `tests/unit/categorizer/` |
+
+### このディレクトリでは扱わないもの
+
+| 対象 | 帰属 |
+|---|---|
+| UI コンポーネント・ページ | `ui/Ph3/` |
+| Playwright e2e | `ui/Ph3/06` |
+| DB スキーマ追加 | なし（Phase 3 ではスキーマ変更しない） |
+| Worker パイプライン変更 | なし（Phase 1〜2 で完了済） |
+
+## タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典 | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 3.1 Flask REST API 主担当 | [`01-flask-rest-api.md`](./01-flask-rest-api.md) | §4.3 L309-319 | `feature/flask-rest-api` | 🔴 高 |
+| 02 | Phase 3.3〜3.5 集計エンドポイント（補助） | [`02-aggregation-endpoints.md`](./02-aggregation-endpoints.md) | §4.3 L333-365 | `feature/api-aggregation-endpoints` | 🟡 中 |
+| 03 | Phase 3.6 ルール dry-run（補助） | [`03-rule-dry-run-endpoint.md`](./03-rule-dry-run-endpoint.md) | §4.3 L367-377 | `feature/api-rule-dry-run` | 🟡 中 |
+
+## 実行順序
+
+```
+[Phase 1 / Phase 2 完了] ←必須前提
+   ↓
+api/Ph3/01 (REST API 基盤)
+   ├─→ api/Ph3/02 (集計)  ─┐
+   └─→ api/Ph3/03 (dry-run)─┴─→ ui/Ph3/* と並行
+```
+
+`api/Ph3/02` と `api/Ph3/03` は `api/Ph3/01` 完了後に **2 並列**で着手可能（Coder 2体）。
+
+## 共通の前提
+
+- **Phase 1 / Phase 2 完了が必須**（特に Phase 1.6 取込CLI で DB に取引データが蓄積されていること）
+- `flask-smorest` を runtime 依存に追加（`api/Ph3/01` で実施、その後の 02/03 は依存追加なし）
+- 認証は `Tailscale-User-Login` ヘッダ前提、開発時は環境変数 `KAKEIBO_API_AUTH_BYPASS=1` でバイパス
+- SQLAlchemy ORM は **不採用**（Phase 1 方針継続）。psycopg のパラメータ化クエリ + 薄いリポジトリ関数で永続化境界を保つ
+- API レスポンスでは `transactions.raw_payload` を **返さない**（`docs/design/05-security-model.md` §10.2、PII 漏洩リスク）
+- 日付返却は `Asia/Tokyo`（compose.yml `TZ` と整合）、内部処理は UTC
+
+## 担当 Worker サブエージェント（モードB前提）
+
+`agent-rules/91-claude-subagent-coding.md` に従う。
+
+| Worker | 主な責務 |
+|---|---|
+| Planner | 認証ミドルウェアの責務分離、リポジトリ層の境界、エラー応答の DTO 設計 |
+| Coder | テスト先行 → エンドポイント実装。`flask-smorest` ベースの自動 OpenAPI |
+| Reviewer | SQL インジェクション耐性、認証バイパスの誤有効化リスク、`raw_payload` 漏洩、レート制限想定（家庭内なので最小） |
+| Git-composer | アトミックコミット、`feature/*` ブランチ運用 |
+
+並列ポリシー: `02` と `03` は `01` 完了後に同一メッセージで Coder 2体並列起動可。
+
+## 共通の品質ゲート
+
+```bash
+pytest tests/unit/api/ tests/integration/api/ tests/unit/categorizer/
+ruff check .
+pyright
+```
+
+統合確認（`api/Ph3/01〜03` 全完了後）：
+- `/api/openapi.json` から OpenAPI が取得でき、`openapi-typescript` で UI 側の型生成が成功
+- `KAKEIBO_API_AUTH_BYPASS=1` での dev 起動から全 CRUD が叩ける
+- 認証ヘッダなしで 401（本番想定）
+
+## Phase3 完了条件カバレッジ（api 担当範囲）
+
+| 完了条件 | 主担当タスク |
+|---|---|
+| (a) REST API CRUD 提供 | `01` + `02` + `03` |
+| (c) UI からルール CRUD（API 側） | `01` + `03` |
+
+(b) (d) (e) は ui 側の責務（`ui/Ph3/`）。

--- a/docs/plans/api/README.md
+++ b/docs/plans/api/README.md
@@ -1,0 +1,63 @@
+---
+title: api サービス Phase1 タスク指示書
+service: api
+phase: 1
+status: NoTasks
+parent_index: docs/plans/10-phase1-overview.md
+last_updated: 2026-05-01
+---
+
+# api サービス Phase1 タスク指示書
+
+## 結論：Phase1 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `api` サービス（Flask + Werkzeug 開発サーバ）は **Phase 0 で完了済み**。`/health` エンドポイントだけを提供する最小スタブで、`docker compose up -d` 後の HEALTHCHECK・Caddy 経由の疎通確認を満たす。
+
+Phase 1 のタスク（1.1〜1.8）はすべて `postgres` または `worker` サービスに帰属する。`docs/plans/10-phase1-overview.md` §2 のタスク一覧と `docs/plans/01-development-plan.md` §4.1 を確認しても、API レイヤを変更する必要があるタスクは存在しない。
+
+## サービス境界（参考）
+
+| 範囲 | パス |
+|---|---|
+| Flask アプリケーションファクトリ | `src/kakeibo/api/app.py`（`/health` のみ） |
+| エントリポイント | `src/kakeibo/api/__main__.py` |
+| Phase3 で REST 拡張する Blueprint | （未配置）`src/kakeibo/api/blueprints/` 想定 |
+| api コンテナ Dockerfile | `api/Dockerfile`（uv マルチステージ） |
+| api コンテナ wrapper | `api/kakeibo_api/__init__.py`（`create_app` 再エクスポートのみ） |
+
+`api` コンテナの Dockerfile は `src/kakeibo` 全体を COPY するため、`worker/01〜07` で実装した共通ライブラリ（domain / adapters / ingest / sql）も同じ image に含まれる。Phase 3.1 で REST API を実装する際はこれを再利用する。
+
+## Phase1 の間に api サービスへ波及する変更（許容例）
+
+ロジックは増やさないが、以下のような **間接的な影響** はあり得る：
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| `pyproject.toml` の `[project.dependencies]` 追加 | 可（再ビルド必要） | `worker` 側のタスクで `click` 等を使う場合、共通の依存定義を更新するため `api` イメージも再ビルドされる |
+| `src/kakeibo/__init__.py` の `__version__` 変更 | 可 | リリース時に同じコミットで `pyproject.toml` の `version` と同期 |
+| `src/kakeibo/config.py`, `logging.py` の改修 | 慎重に | 既存テスト（`tests/unit/test_settings_repr.py` など）を壊さないこと |
+| `api/Dockerfile` の変更 | 原則不要 | Phase 1 内では変更不要のはず。必要になったら別タスク化 |
+
+これらは **既存の動作を壊さない** ことを最優先する（`agent-rules/00-core-principles.md` 絶対遵守の3原則 §1 デグレッション防止）。
+
+## Phase 3.1 への申し送り
+
+Phase 3 で本サービスに本格着手するときの起点：
+
+- 原典: `docs/plans/01-development-plan.md` §4.3 Phase 3.1 Flask REST API
+- ブランチ: `feature/flask-rest-api`
+- 関連 ADR: ADR-009（NAS + Docker Compose）, ADR-010（Tailscale 限定アクセス）
+- 関連 design: `docs/design/04-deployment-stack.md`, `docs/design/05-security-model.md`
+- 想定エンドポイント: `GET /api/balances`, `GET /api/transactions`, `GET/POST/PUT/DELETE /api/categories`, `GET/POST/PUT/DELETE /api/rules`
+
+Phase 3.1 着手時に本ディレクトリへ `01-flask-rest-api.md` 等の指示書を追加する。
+
+## 担当 Worker サブエージェント
+
+Phase1 期間中に発生する可能性があるのは **Reviewer のみ**：
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `worker` 側のタスクが `pyproject.toml` や `src/kakeibo/__init__.py` を変更した際、`api` コンテナのビルド・起動に影響しないかを Read のみで確認 |
+
+Coder / Planner / Git-composer の起動は Phase1 では原則不要。

--- a/docs/plans/postgres/01-schema-migrations.md
+++ b/docs/plans/postgres/01-schema-migrations.md
@@ -1,0 +1,152 @@
+---
+title: postgres/01 DBスキーマ・マイグレーション基盤
+service: postgres
+phase_task_id: 1.1
+priority: 高
+source_plan: docs/plans/02-phase1-db-schema-and-migrations.md
+branch: feature/db-schema-initial
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# postgres/01 DBスキーマ・マイグレーション基盤（Phase 1.1）
+
+## このファイルの位置付け
+
+原典プラン `docs/plans/02-phase1-db-schema-and-migrations.md` をサブエージェントが指示書 1 枚で着手できる形に再編した、`postgres` サービス担当の **実装タスクシート**。原典は変更しない。本指示書と原典で内容が乖離した場合は **原典を優先** する（`docs/plans/01-development-plan.md` §1.4 改版方針）。
+
+## 担当サービス
+
+`compose.yml` `postgres` サービス（PostgreSQL 16-alpine）。Alembic マイグレーションの **スキーマ正本** が本タスクで確定する。実行は `worker` コンテナまたは開発ホストの venv から `alembic upgrade head`。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流（依存） | なし（Phase1 起点） |
+| 下流（本タスクが解放） | `worker/01-domain-types.md` 以降のすべて |
+
+`docs/plans/10-phase1-overview.md` §4 のクリティカルパス起点。
+
+## 入力（Coder が読むべきファイル）
+
+1. **原典プラン**: `docs/plans/02-phase1-db-schema-and-migrations.md`（必読・全文）
+2. **DDL 定義**: `docs/plans/00-initial-design.md` §4.2
+3. **データモデル**: `postgres/docs/design/01-data-model.md`
+4. **関連 ADR**: `docs/adr/004-postgres-jsonb.md` / `005-numeric-money-type.md` / `006-hash-uniqueness.md`
+5. **Alembic 既存資産**: `alembic.ini`, `alembic/env.py`（再初期化禁止。`target_metadata` は Phase1 では `None` 維持）
+6. **既存テストユーティリティ**: `tests/_compose_utils.py`（テスト用 Postgres 起動）
+7. **依存宣言**: `pyproject.toml` `[project.optional-dependencies].dev` の `testcontainers`
+
+## 期待される出力ファイル
+
+| パス | 区分 | 役割 |
+|---|---|---|
+| `alembic/versions/0001_create_institutions_and_accounts.py` | 新規 | 機関・口座テーブル |
+| `alembic/versions/0002_create_categories.py` | 新規 | カテゴリ階層 |
+| `alembic/versions/0003_create_transactions.py` | 新規 | 取引テーブル + `hash` UNIQUE + `category_source` ENUM |
+| `alembic/versions/0004_create_holdings_and_snapshots.py` | 新規 | 保有銘柄・残高スナップショット |
+| `alembic/versions/0005_create_categorization_rules.py` | 新規 | カテゴリルール |
+| `tests/unit/db/__init__.py` | 新規 | テストパッケージ初期化 |
+| `tests/unit/db/conftest.py` | 新規（任意） | 一時 Postgres コンテナの session-scope fixture |
+| `tests/unit/db/test_schema.py` | 新規 | 7 テーブル・主要カラム型・UNIQUE・ENUM の存在検証 |
+| `tests/unit/db/test_migration_idempotency.py` | 新規 | 2 回連続 `alembic upgrade head` が no-op |
+| `src/kakeibo/db/__init__.py` | 既存（追記） | テスト共有用 engine factory のエクスポート（既存 `session.py` を再利用） |
+
+`alembic/env.py` の改修は **必要時のみ**（`target_metadata` を bind したくなった場合）。Phase1 では Raw SQL ベースで進めるため、原則は `None` のまま。
+
+## 実装手順（TDD: Red → Green → Refactor）
+
+### 0. ブランチ作成
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b feature/db-schema-initial
+```
+
+### 1. Red: テストを先に書く
+
+1. `tests/unit/db/test_schema.py` に「7 テーブル存在 / `transactions.amount` が NUMERIC(18,4) / `transactions.hash` UNIQUE / `category_source` ENUM 値が `('rule','llm','manual')`」の検証を `information_schema` ベースで記述。
+2. `tests/unit/db/test_migration_idempotency.py` に「`alembic upgrade head` を 2 回連続実行して `transactions` 行数が 0 のまま、テーブル数も同一」の検証を記述。
+3. `tests/unit/db/conftest.py` で `testcontainers.postgres.PostgresContainer` を session-scope で立ち上げ、`DATABASE_URL` を注入する fixture を提供。
+4. `pytest tests/unit/db/` を流して **全件落ちる** ことを確認。
+
+### 2. Green: マイグレーションを 5 分割で追加
+
+各 versions ファイルは **1 ファイル = 1 コミット**。`down_revision` を線形に連結する。
+
+| ファイル | 主要 DDL |
+|---|---|
+| `0001_*` | `institutions`, `accounts` |
+| `0002_*` | `categories`（自己参照 FK 含む） |
+| `0003_*` | `category_source` ENUM 作成 → `transactions`（`amount NUMERIC(18,4) NOT NULL`, `hash CHAR(64) NOT NULL UNIQUE`, `raw_payload JSONB DEFAULT '{}'`） |
+| `0004_*` | `holdings`, `balance_snapshots`（同日同口座 UNIQUE） |
+| `0005_*` | `categorization_rules` |
+
+各ファイル追加ごとに対応する pytest ケースが緑になることを確認しながら進める。
+
+### 3. Refactor
+
+- ENUM 作成・削除を `_create_category_source_enum(op)` のような共通ヘルパに抽出可能なら抽出（同一マイグレーション内のみ）。
+- マイグレーション間で重複する制約名命名規約（`ix_<table>_<col>` / `uq_<table>_<col>`）を確定。
+
+## 受入条件（コミット前にすべて緑）
+
+- `alembic upgrade head` が空 DB に対して成功する
+- `alembic upgrade head` を 2 回連続実行して 2 回目が no-op で成功する
+- `pytest tests/unit/db/` が全件緑（10 秒以内）
+- `transactions.amount` に文字列を投入すると PostgreSQL の型エラーで弾かれる
+- `transactions.hash` への重複 INSERT が `psycopg.errors.UniqueViolation`
+- `category_source` ENUM に範囲外値を投入すると例外
+- `pyright` クリーン、`ruff check` 違反ゼロ
+
+## 品質ゲート（`agent-rules/00-core-principles.md` コミット前ユニバーサルチェック）
+
+```bash
+pytest tests/unit/db/        # 全件緑
+ruff check .                 # 違反ゼロ
+pyright                      # 警告ゼロ
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/db-schema-initial`（`develop` 起点）
+- コミット粒度（最低 6 件、`agent-rules/10-git-strategy.md` 準拠）：
+  1. `テスト: スキーマ存在・冪等性検証テストを先行作成`
+  2. `機能: 機関・口座テーブルのマイグレーション追加`
+  3. `機能: カテゴリ階層テーブルのマイグレーション追加`
+  4. `機能: 取引テーブルとhash UNIQUE制約・category_source ENUMを追加`
+  5. `機能: 保有銘柄・残高スナップショットテーブルのマイグレーション追加`
+  6. `機能: カテゴリルールテーブルのマイグレーション追加`
+- 各メッセージは日本語 1〜2 文・WHY 優先。
+- マージは `develop` への fast-forward。
+
+## 完了報告テンプレ（Coder → メイン）
+
+```markdown
+## 実施内容
+Phase 1.1 DBスキーマ・マイグレーション基盤を実装。
+
+## 成果物
+- alembic/versions/0001_*.py 〜 0005_*.py
+- tests/unit/db/test_schema.py / test_migration_idempotency.py / conftest.py
+
+## 検証結果
+- pytest tests/unit/db/: 全件緑（X 秒）
+- alembic upgrade head 2 回実行: 冪等成功
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+（あれば）
+
+## 次のアクション提案
+worker/01-domain-types.md（Phase 1.2）の着手準備が整った。
+```
+
+## 注意事項
+
+- 既存の `alembic/`・`alembic.ini`・`alembic/env.py` を **再初期化禁止**（`alembic init` を打たない）。
+- `pytest-postgresql` は dev 依存に未宣言。**`testcontainers` を使用** する（pyproject.toml で宣言済み）。
+- ENUM のダウン側で型もドロップする。
+- `target_metadata` は Phase1 では `None` 維持（SQLAlchemy ORM は Phase 1.2 では使わず、共通型は dataclass で実装）。

--- a/docs/plans/postgres/Ph2/README.md
+++ b/docs/plans/postgres/Ph2/README.md
@@ -1,0 +1,56 @@
+---
+title: postgres サービス Phase2 タスク指示書
+service: postgres
+phase: 2
+status: NoTasks
+parent_index: docs/plans/12-phase2-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# postgres サービス Phase2 タスク指示書
+
+## 結論：Phase2 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `postgres` サービス（PostgreSQL 16-alpine）は Phase 1.1（`postgres/Ph1/01-schema-migrations.md`）でスキーマが確定する設計。Phase 2 ではメール取込（Amazon / 楽天 / Yahoo）と PayPal API 取込を `transactions` テーブルに **正規化済みの形で投入** するため、**スキーマ変更は発生しない**。
+
+`docs/plans/01-development-plan.md` §4.2 のタスク 2.1〜2.8 をすべて確認しても、DB スキーマを拡張する項目はない。
+
+## サービス境界（参考）
+
+| 範囲 | パス | Phase 2 での扱い |
+|---|---|---|
+| Alembic マイグレーション本体 | `alembic/versions/0001〜0005_*.py` | **追加・変更なし** |
+| `transactions.raw_payload` JSONB | DB スキーマ | 既存定義のまま、メール / PayPal の生データもここに格納 |
+| ENUM `category_source` | DB スキーマ | 既存値 `('rule','llm','manual')` のまま使用 |
+| バックアップサービス | `compose.yml` `backup` | 既存の `pg_dump` 日次運用で十分 |
+
+## Phase2 の間に postgres サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| `compose.yml` `postgres` 環境変数の変更 | 不要 | – |
+| `postgres` ヘルスチェックの変更 | 不要 | – |
+| `transactions.raw_payload` のキー命名規約の合意 | 推奨（指示書レベルで完結） | Amazon/楽天/Yahoo/PayPal で共通の JSON キー命名（例: `order_id`, `transaction_id`, `points_used`）を `worker/Ph2/04〜07` の各指示書で固定済み |
+
+`agent-rules/00-core-principles.md` 絶対遵守の3原則 §1 デグレッション防止に従い、**既存スキーマと既存テスト（`tests/unit/db/`）を壊さない** ことを最優先する。
+
+## Phase 4 への申し送り
+
+Phase 4 で本サービスに変更が必要となる候補：
+
+- LLM 分類結果の専用フィールド追加（`category_source='llm'` の確信度・モデル名等を `raw_payload` に乗せるか専用カラムを追加するかの設計判断、原典 `docs/plans/01-development-plan.md` §4.4 Phase 4.1）
+- Reconciler の `linked_tx_id` 列追加（Phase 4.3）
+- `categorization_rules` の優先度カラム追加（Phase 3.6 / 4.2）
+
+これらは Phase 4 着手時に `docs/plans/postgres/Ph4/` を新設して扱う。
+
+## 担当 Worker サブエージェント
+
+Phase2 期間中に発生する可能性があるのは **Reviewer のみ**：
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `worker/Ph2/03〜07` で `raw_payload` に投入される JSON 構造が、既存 `transactions.raw_payload` の JSONB として problem なく格納されることを Read のみで確認 |
+| Reviewer | `worker/Ph2/01〜02` で取込される CSV メタ情報（archive 移動先など）が、既存 `institutions` / `accounts` テーブルの参照整合性を破壊しないことを確認 |
+
+Coder / Planner / Git-composer の起動は Phase2 では原則不要。

--- a/docs/plans/postgres/Ph3/README.md
+++ b/docs/plans/postgres/Ph3/README.md
@@ -1,0 +1,57 @@
+---
+title: postgres サービス Phase3 タスク指示書
+service: postgres
+phase: 3
+status: NoTasks
+parent_index: docs/plans/13-phase3-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# postgres サービス Phase3 タスク指示書
+
+## 結論：Phase3 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `postgres` サービスのスキーマは Phase 1.1 で確定済み。Phase 3 は **既存の `transactions` / `categories` / `categorization_rules` / `holdings` / `balance_snapshots` を読み出して REST API 経由で UI に提供する** だけのため、スキーマ変更は発生しない。
+
+`docs/plans/01-development-plan.md` §4.3 のタスク 3.1〜3.6 をすべて確認しても、DB スキーマを拡張する項目はない。
+
+## サービス境界（参考）
+
+| 範囲 | パス | Phase 3 での扱い |
+|---|---|---|
+| Alembic マイグレーション | `alembic/versions/0001〜0005_*.py` | **追加・変更なし** |
+| 月次サマリ SQL（Phase 1.8） | `sql/queries/monthly_summary.sql` | 既存のまま、`api/Ph3/02` から呼び出される |
+| 集計 SQL（Phase 3 で追加） | `sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql` | **`api` サービス帰属**（`api/Ph3/02-aggregation-endpoints.md` で実装） |
+| バックアップサービス | `compose.yml` `backup` | 既存運用維持 |
+
+## Phase3 の間に postgres サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| インデックス追加 | 不要 | Phase 3 完了後に運用ベンチで遅延が顕在化したら別タスク化 |
+| `compose.yml` `postgres` 環境変数の変更 | 不要 | – |
+| ヘルスチェック変更 | 不要 | – |
+| `transactions.raw_payload` JSONB の利用拡張 | 不要 | API レスポンスでは `raw_payload` を返さない方針（PII リスク、`docs/design/05-security-model.md` §10.2） |
+
+`agent-rules/00-core-principles.md` 絶対遵守の3原則 §1 デグレッション防止に従い、**既存スキーマと既存テスト（`tests/unit/db/`）を壊さない** ことを最優先する。
+
+## Phase 4 への申し送り
+
+Phase 4 で本サービスに変更が必要となる候補：
+
+- LLM 分類結果の専用フィールド追加（Phase 4.1）
+- Reconciler の `linked_tx_id` カラム追加（Phase 4.3）
+- `categorization_rules` への `is_dismissed` フラグ追加（Phase 4.2 半自動学習で「拒否したら再提案しない」）
+
+これらは Phase 4 着手時に `docs/plans/postgres/Ph4/` を新設して扱う。
+
+## 担当 Worker サブエージェント
+
+Phase3 期間中に発生する可能性があるのは **Reviewer のみ**：
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `api/Ph3/02` で追加される集計 SQL（`monthly_balance_trend.sql` 等）が既存スキーマの参照整合性を破壊しないこと、JOIN がパフォーマンス上問題ないことを Read のみで確認 |
+| Reviewer | `api/Ph3/01` のリポジトリ層が psycopg のパラメータ化クエリを正しく使い、SQL インジェクション耐性を持つことを確認 |
+
+Coder / Planner / Git-composer の起動は Phase3 では原則不要。

--- a/docs/plans/postgres/README.md
+++ b/docs/plans/postgres/README.md
@@ -1,0 +1,64 @@
+---
+title: postgres サービス Phase1 タスク指示書
+service: postgres
+phase: 1
+status: Ready
+parent_index: docs/plans/10-phase1-overview.md
+last_updated: 2026-05-01
+---
+
+# postgres サービス Phase1 タスク指示書
+
+`compose.yml` の `postgres` サービス（PostgreSQL 16-alpine 単一コンテナ + Alembic マイグレーション本体）に紐づく Phase1 タスクをまとめる。原典プランは `docs/plans/02-phase1-db-schema-and-migrations.md`。
+
+## サービス境界（このディレクトリで扱うもの）
+
+- `alembic/versions/*.py` のマイグレーションスクリプト（=`postgres` コンテナのスキーマ正本）
+- スキーマ存在検証・冪等性検証の pytest（`tests/unit/db/`）
+- ENUM・CHECK・UNIQUE 等の制約定義
+- `src/kakeibo/db/` の最小ヘルパ（マイグレーションテストで再利用される engine factory のみ）
+
+### このディレクトリでは扱わないもの
+
+| 対象 | 帰属サービス |
+|---|---|
+| ドメイン型 / アダプタ / 取込CLI | `worker` サービス（`docs/plans/worker/`） |
+| 月次サマリ SQL のクエリ本体・ランナー | `worker` サービス（`docs/plans/worker/07-monthly-summary-sql.md`） |
+| Flask `/health` エンドポイント | `api` サービス（Phase 0 で完了済み） |
+| Next.js UI | `ui` サービス（Phase1 では着手なし） |
+
+実行コンテナは `postgres` だが、Alembic 自体は `worker` コンテナまたは開発ホストから `alembic upgrade head` を叩く運用（`compose.yml` の worker は `src/` を持っている）。スキーマの **正本** が `postgres` 帰属であって、実行主体は worker という関係。
+
+## タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典プラン | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 1.1 DBスキーマ・マイグレーション基盤 | [`01-schema-migrations.md`](./01-schema-migrations.md) | `docs/plans/02-phase1-db-schema-and-migrations.md` | `feature/db-schema-initial` | 🔴 高 |
+
+## 実行順序
+
+`postgres` サービスのタスクは Phase1 の **最上流**（`docs/plans/10-phase1-overview.md` §3 の直列上流）。`worker` サービス側のすべてのタスクが本タスク完了を起点とする。
+
+```
+postgres/01 → worker/01 → worker/02 → worker/03 ↘
+                                    → worker/04 → worker/05 → worker/06
+                                                            → worker/07
+```
+
+## 前提
+
+- `compose.yml` `postgres` サービスは `Dockerfile` を持たず、`postgres:16-alpine` 公式イメージそのまま使用。
+- secret は `./secrets/pg_password.txt`（既に運用上は配置済前提）。
+- Alembic 設定（`alembic.ini` / `alembic/env.py`）は Phase 0 で配備済み。`resolve_database_url()` は環境変数 `DATABASE_URL` から接続文字列を解決する。
+- マイグレーション作業時は `worker` コンテナ内、または開発ホストの venv から `alembic upgrade head` を実行する。
+
+## 担当 Worker サブエージェント（モードB前提）
+
+`agent-rules/91-claude-subagent-coding.md` に従い、メインClaudeはオーケストレーターに徹し、以下を起動する：
+
+| Worker | 役割 |
+|---|---|
+| Planner | マイグレーション 5 ファイル分割の確定、`information_schema` クエリ仕様の起案 |
+| Coder | テスト先行（`test_schema.py` / `test_migration_idempotency.py`）→ Alembic versions 実装 |
+| Reviewer | ADR-004/005/006 と DDL の整合、CHECK 制約の網羅性、冪等性 |
+| Git-composer | `feature/db-schema-initial` でアトミックコミット 5 件以上（テスト先行 → 各 versions ファイル → ヘルパ） |

--- a/docs/plans/ui/Ph2/README.md
+++ b/docs/plans/ui/Ph2/README.md
@@ -1,0 +1,51 @@
+---
+title: ui サービス Phase2 タスク指示書
+service: ui
+phase: 2
+status: NoTasks
+parent_index: docs/plans/12-phase2-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# ui サービス Phase2 タスク指示書
+
+## 結論：Phase2 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `ui` サービス（Next.js 雛形）は Phase 0 で配備済み。Phase 1 と同様、Phase 2 でも **本格着手しない**。
+
+`docs/plans/01-development-plan.md` §4.2 のタスク 2.1〜2.8 はバックエンド自動取込のみで、UI で操作する画面や設定変更フローは含まれない。
+
+## サービス境界（参考）
+
+| 範囲 | Phase 2 での扱い |
+|---|---|
+| Next.js アプリ（`ui/app/`） | 変更なし |
+| Dockerfile / `package.json` | 変更なし |
+| `tests/unit/test_ui_nextjs.py` | 既存挙動を維持 |
+
+## Phase2 の間に ui サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| UI 雛形に手を入れる | 不要 | Phase 2 では一切変更しない |
+| `ui/Dockerfile` の改修 | 不要 | – |
+
+`agent-rules/00-core-principles.md` 3原則 §1 デグレッション防止に従い、UI 側の既存テスト（`tests/unit/test_ui_nextjs.py`）を壊さないこと。
+
+## Phase 3.2 への申し送り
+
+Phase 3 で本サービスに本格着手するときの起点：
+
+- 原典: `docs/plans/01-development-plan.md` §4.3 Phase 3.2 React Dashboard 雛形
+- ブランチ: `feature/react-dashboard-scaffold`
+- Phase 2 完了時点で `worker` 側に取引データが日次で蓄積される状態になっているので、Phase 3.3 月次推移グラフが意味のあるデータを描画できる前提が整う
+
+Phase 3.2 着手時に `docs/plans/ui/Ph3/01-react-dashboard-scaffold.md` を新設する。
+
+## 担当 Worker サブエージェント
+
+Phase2 期間中は原則不要。
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `tests/unit/test_ui_nextjs.py` が共通設定変更（`pyproject.toml` 等）で破壊されていないか Read のみで確認 |

--- a/docs/plans/ui/Ph3/01-react-dashboard-scaffold.md
+++ b/docs/plans/ui/Ph3/01-react-dashboard-scaffold.md
@@ -1,0 +1,296 @@
+---
+title: ui/Ph3/01 React Dashboard 雛形
+service: ui
+phase_task_id: 3.2
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.2（行 321-331）
+branch: feature/react-dashboard-scaffold
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/01 React Dashboard 雛形（Phase 3.2）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.3 Phase 3.2 を `ui` サービス担当の指示書として展開。Phase 3 ui タスク群（02〜06）すべての **基盤**となるクリティカルパス上のタスク。
+
+**原典との重要な差分**: 原典は「Vite + TypeScript + React」を指定しているが、本指示書は **Next.js 14 App Router を維持**する方針を採用する（Phase 0 の Dockerfile / standalone build / healthcheck / 既存テストを保護するため、`agent-rules/00-core-principles.md` §1 デグレッション防止）。原典の本質である「TypeScript + React」は採用、ビルド基盤のみ Next.js に固定。原典は不変扱い（Phase 1〜2 と同じ慣習）。
+
+## 担当サービス
+
+`compose.yml` `ui` サービス（Next.js 14、Node.js 20 LTS）。`ui/Dockerfile` の standalone build と healthcheck 互換性を維持しつつ、ライブラリ・コンポーネント・テスト基盤を整備する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `api/Ph3/01`（OpenAPI スキーマが取得できる） |
+| 下流 | `ui/Ph3/02`〜`05`（共通レイアウト・APIクライアント前提）, `ui/Ph3/06`（Playwright） |
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.2（行 321-331）
+2. **デプロイ**: `docs/design/04-deployment-stack.md` §3 / §6（Caddy `/` → ui:3000、`/api/*` → api:8000）
+3. **フロントエンド規約**: `agent-rules/15-frontend-design.md`（**必読**）
+4. **テスト戦略**: `agent-rules/11-testing-strategy.md`
+5. **既存資産**: `ui/{app/{layout,page}.tsx, Dockerfile, next.config.mjs, tsconfig.json, package.json, package-lock.json}`
+6. **既存テスト**: `tests/unit/test_ui_nextjs.py`（Python 側、UI 設定の構造検証 — 破壊しないこと）
+7. **API 基盤**: `api/Ph3/01-flask-rest-api.md` で実装される OpenAPI 仕様（`/api/openapi.json`）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `ui/package.json` | 依存追加（後述） |
+| `ui/tsconfig.json` | `paths` 拡張（`@/lib/*`, `@/components/*`） |
+| `ui/next.config.mjs` | `/api/*` を `process.env.API_BASE_URL`（既定 `http://api:8000`）にプロキシ |
+| `ui/postcss.config.js` | Tailwind / autoprefixer |
+| `ui/tailwind.config.ts` | カスタムフォント・カラートークン |
+| `ui/styles/globals.css` | Tailwind ディレクティブ + デザイントークン CSS 変数 |
+| `ui/lib/api/client.ts` | `fetch` ラッパ（タイムアウト / エラー正規化） |
+| `ui/lib/api/types.gen.ts` | OpenAPI から自動生成（`openapi-typescript`） |
+| `ui/lib/api/{transactions,categories,rules,balances,aggregations}.ts` | エンドポイント別 thin client |
+| `ui/lib/query/provider.tsx` | `QueryClientProvider` |
+| `ui/components/layout/AppShell.tsx` | サイドバー + ヘッダ + コンテンツ |
+| `ui/components/feedback/{EmptyState,ErrorState,LoadingState}.tsx` | 共通状態コンポーネント |
+| `ui/app/layout.tsx` | App Router ルート（既存拡張、`AppShell` 組込） |
+| `ui/app/page.tsx` | ダッシュボードトップ（プレースホルダ → 02〜05 で内容追加） |
+| `ui/test/setup.ts` | vitest + Testing Library セットアップ |
+| `ui/test/msw/{server,handlers}.ts` | MSW モックサーバ |
+| `ui/vitest.config.ts` | jsdom 環境、`@/` paths |
+| `ui/lib/api/__tests__/client.test.ts` | `fetch` ラッパのテスト |
+| `ui/components/__tests__/AppShell.test.tsx` | レイアウト Render テスト |
+| `ui/components/__tests__/feedback.test.tsx` | 状態コンポーネントテスト |
+
+`npm run generate:api` スクリプトで `/api/openapi.json` から型再生成可能にする（`package.json` の `scripts` に追加）。
+
+## 実装方針
+
+### 1. Next.js 14 App Router 維持
+
+- Phase 0 の `ui/Dockerfile`（standalone build）/ healthcheck / `tests/unit/test_ui_nextjs.py` を **絶対に壊さない**
+- 原典の「Vite」は採用しない（理由は本ファイル冒頭参照）
+- React Server Components を活用：データ取得は Server Component、インタラクティブ UI は `"use client"`
+
+### 2. 状態管理: `@tanstack/react-query` v5
+
+- データ取得・キャッシュ・mutate の業界標準
+- エラー時のリトライは既定で **無効化**（fetch ラッパ側で正規化したエラーをそのまま伝播）
+- `staleTime: 30s`, `gcTime: 5min` 既定
+
+### 3. API クライアント型: `openapi-typescript` で機械生成
+
+- `ui/lib/api/types.gen.ts` を `npm run generate:api` で再生成
+- 手書き型は禁止（DRY、API 仕様との乖離防止）
+- 生成スクリプト例: `openapi-typescript http://api:8000/api/openapi.json -o ui/lib/api/types.gen.ts`
+
+### 4. グラフライブラリ: `recharts`
+
+- React ファースト・MIT・Server Component 互換性あり（Client Component で利用）
+- `Chart.js` / `visx` は採用しない（後者は学習コスト、前者は命令的）
+
+### 5. CSS: Tailwind + デザイントークン
+
+- `tailwindcss` で utility-first
+- デザイントークン（フォント・カラー・スペーシング）は `tailwind.config.ts` の `theme.extend` に集約
+- **フォント**: `Noto Sans JP` + 日本語ディスプレイフォント（`Zen Kaku Gothic Antique` / `Reggae One` 等の選定は Coder/Reviewer 判断）
+- **禁止フォント**: `Inter`, `Roboto`, `Helvetica`, system-ui defaults（`agent-rules/15-frontend-design.md`）
+
+### 6. 認証
+
+- 本番 Caddy が `Tailscale-User-Login` ヘッダを後段に伝播する前提
+- UI 側はそのヘッダを意識しない（API 呼出時はそのまま fetch、ヘッダは Caddy が追加）
+- ログイン UI は **実装しない**（Tailscale 認証で代替）
+
+### 7. dev サーバ起動と環境変数
+
+- `npm run dev` で `next dev` を起動（既存挙動を維持）
+- `API_BASE_URL` 環境変数で API 接続先を切替（compose では `http://api:8000`、ローカル `http://localhost:8000`）
+- `next.config.mjs` の `rewrites()` で `/api/*` → `${API_BASE_URL}/api/*` に変換
+
+### 8. テスト基盤
+
+- `vitest` + `@testing-library/react` + `@testing-library/jest-dom`
+- `msw`（Mock Service Worker）で API モック
+- jsdom 環境
+- Playwright は別タスク（`ui/Ph3/06`）
+
+### 9. AppShell レイアウト
+
+- サイドバー: 残高 / 取引 / カテゴリ / ポートフォリオ / ルール の 5 リンク
+- ヘッダ: アプリ名 + 現在の Tailscale ユーザ表示（`/api/me` で取得、Phase 3.1 で実装）
+- メインコンテンツ領域: `children` を渡す
+- レスポンシブ: 家庭内 PC / iPad で利用想定、モバイルは Phase 4 以降で評価
+
+## 依存パッケージ追加（`ui/package.json`）
+
+### runtime
+
+- `@tanstack/react-query@^5`
+- `recharts@^2`
+- `zod@^3`
+- `clsx@^2`
+
+### dev
+
+- `vitest@^2`
+- `@vitest/ui`
+- `@testing-library/react@^16`
+- `@testing-library/jest-dom@^6`
+- `@testing-library/user-event@^14`
+- `jsdom@^24`
+- `msw@^2`
+- `tailwindcss@^3`
+- `postcss@^8`
+- `autoprefixer@^10`
+- `openapi-typescript@^7`
+
+`eslint-config-next` は Next.js 14 既定で同梱。
+
+## 実装手順（TDD）
+
+### 0. ブランチ作成
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b feature/react-dashboard-scaffold
+```
+
+### 1. Red
+
+`ui/lib/api/__tests__/client.test.ts`：
+- `fetch` 失敗時に `ApiError` を throw
+- タイムアウト時に `TimeoutError`
+- エラーレスポンスの `error.code` をパース
+
+`ui/components/__tests__/AppShell.test.tsx`：
+- ナビゲーションリンク 5 項目が描画
+- 現在ユーザ名がヘッダに表示（MSW で `/api/me` モック）
+- アクティブなナビ項目がスタイル反映
+
+`ui/components/__tests__/feedback.test.tsx`：
+- `EmptyState` が `description` プロパティを表示
+- `ErrorState` が `error.code` を表示
+- `LoadingState` が `aria-busy="true"` を持つ
+
+`pyproject` 系既存テストも引き続き緑（`tests/unit/test_ui_nextjs.py`）。
+
+`npm run test` で全件赤を確認。
+
+### 2. Green
+
+1. `ui/package.json` に依存追加 → `npm install`
+2. `ui/tailwind.config.ts`, `ui/postcss.config.js`, `ui/styles/globals.css` を実装
+3. `ui/tsconfig.json` の `paths` 設定
+4. `ui/next.config.mjs` の `rewrites()` 設定
+5. `ui/vitest.config.ts`, `ui/test/setup.ts`, `ui/test/msw/{server,handlers}.ts` を実装
+6. `ui/lib/api/client.ts`, `types.gen.ts`（生成）, `{transactions,...}.ts` を実装
+7. `ui/lib/query/provider.tsx` を実装
+8. `ui/components/feedback/{EmptyState,ErrorState,LoadingState}.tsx` を実装
+9. `ui/components/layout/AppShell.tsx` を実装
+10. `ui/app/layout.tsx` で `AppShell` + `QueryClientProvider` 統合
+11. `ui/app/page.tsx` をダッシュボードトップ（プレースホルダ）に
+
+`package.json` `scripts`：
+```json
+{
+  "dev": "next dev",
+  "build": "next build",
+  "start": "next start",
+  "lint": "next lint",
+  "test": "vitest run",
+  "test:watch": "vitest",
+  "generate:api": "openapi-typescript ${API_BASE_URL:-http://localhost:8000}/api/openapi.json -o lib/api/types.gen.ts",
+  "typecheck": "tsc --strict --noEmit"
+}
+```
+
+### 3. Refactor
+
+- `client.ts` のエラー正規化を `_normalize_error(response)` ヘルパに抽出
+- AppShell のナビゲーション項目を `_NAV_ITEMS` 定数化
+
+## 受入条件
+
+原典 §4.3 Phase 3.2 受入基準：
+- `npm run dev` で起動
+- `tsc --strict` クリーン
+- API クライアントと型定義が API スキーマと一致（`openapi-typescript` で機械生成）
+- vitest + Testing Library が動作
+
+加えて：
+- `npm run build` が standalone 出力で成功（既存 Dockerfile 互換）
+- `npm run lint`（next lint）違反ゼロ
+- `npm run test` 全件緑
+- `npm run typecheck` 全件緑
+- MSW で OpenAPI スキーマ準拠のモックレスポンスが返せる
+- `agent-rules/15-frontend-design.md` の禁止フォント / 配色を採用していない（Reviewer チェック）
+- `npm run generate:api` で型再生成可能
+- `tests/unit/test_ui_nextjs.py` が引き続き緑
+
+## 品質ゲート
+
+```bash
+cd ui
+npm install
+npm run lint
+npm run test
+npm run build
+npm run typecheck
+
+# Python 側既存テスト
+cd ..
+pytest tests/unit/test_ui_nextjs.py
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/react-dashboard-scaffold`
+- コミット粒度（最低 7 件）：
+  1. `テスト: APIクライアント・AppShell・状態コンポーネントのテストを先行作成`
+  2. `設定: vitest / Testing Library / MSW / Tailwind / openapi-typescript を導入`
+  3. `機能: APIクライアント（fetchラッパ + 型生成スクリプト）を実装`
+  4. `機能: react-query Provider と共通状態コンポーネントを実装`
+  5. `機能: AppShell レイアウトとデザイントークン（フォント・配色）を実装`
+  6. `設定: Next.js next.config.mjs の API リライトと dev サーバ環境変数を整備`
+  7. `機能: app router layout に Provider と AppShell を統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.2 React Dashboard 雛形を実装。
+
+## 成果物
+- ui/package.json（依存追加 + scripts）
+- ui/lib/api/{client,*.ts}
+- ui/lib/query/provider.tsx
+- ui/components/{layout/AppShell,feedback/*}.tsx
+- ui/styles/globals.css + tailwind 設定
+- ui/test/{setup.ts, msw/*}
+- ui/vitest.config.ts
+- ui/app/{layout,page}.tsx（拡張）
+- ui/next.config.mjs（rewrites 追加）
+
+## 検証結果
+- npm run lint / test / build / typecheck: 全件緑
+- tsc --strict クリーン
+- tests/unit/test_ui_nextjs.py: 既存挙動維持
+- 禁止フォント未使用を Reviewer 確認済み
+
+## 次のアクション提案
+ui/Ph3/02-04（残高 / カテゴリ / ポートフォリオ）が 3 並列で着手可能。
+ui/Ph3/05（ルール編集UI）も並行可能。
+```
+
+## 注意事項
+
+- **`ui/Dockerfile` を絶対に壊さない**（standalone build / healthcheck 互換）。Tailwind の build 時 CSS 確定は standalone と互換。
+- **MSW の Service Worker 登録は dev only**（`npm run build` には乗せない、Phase 0 の本番イメージサイズに影響させない）。
+- **`tests/unit/test_ui_nextjs.py` 互換性**: `package.json` の構造変更時にこの Python テストが期待する `name` / `scripts` / `dependencies` の存在条件を確認する。破壊する場合は同コミットでテストも更新。
+- **Server Component vs Client Component**: グラフ・フォーム・状態管理が必要なコンポーネントは `"use client"` を付ける。データ取得は可能な限り Server Component で。
+- **API 型生成のタイミング**: `api/Ph3/01` 完了後、最初に `npm run generate:api` を実行して `types.gen.ts` を取得。CI には組まない（Phase 3 内では手動）。
+- **デザイン判断**: `agent-rules/15-frontend-design.md` の方向性（記憶に残るデザイン、禁止フォント・配色）について不明点があればユーザに確認。フォント候補（`Noto Sans JP` + ディスプレイフォント）は仮で、最終決定は Reviewer + ユーザ承認推奨。

--- a/docs/plans/ui/Ph3/02-monthly-trend-chart.md
+++ b/docs/plans/ui/Ph3/02-monthly-trend-chart.md
@@ -1,0 +1,143 @@
+---
+title: ui/Ph3/02 月次推移グラフ
+service: ui
+phase_task_id: 3.3
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.3（行 333-343）
+branch: feature/monthly-trend-chart
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/02 月次推移グラフ（Phase 3.3）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.3 を `ui` サービス担当の指示書として展開。`ui/Ph3/01` の基盤と `api/Ph3/02` の集計エンドポイントを利用して、全口座合計残高の月次推移を `recharts` の `LineChart` で表示する。
+
+## 担当サービス
+
+`compose.yml` `ui` サービス。`ui/app/balances/` に残高ページを追加し、期間フィルタ + 折れ線グラフ + 空状態 UI を実装する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `ui/Ph3/01`（雛形）+ `api/Ph3/02`（`/api/balances/monthly`） |
+| 下流 | `ui/Ph3/06`（Playwright e2e） |
+
+`ui/Ph3/03` / `04` / `05` と並列着手可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.3（行 333-343）
+2. **デプロイ**: `docs/design/04-deployment-stack.md`
+3. **API 仕様**: `api/Ph3/02-aggregation-endpoints.md` の `/api/balances/monthly`
+4. **デザイン**: `agent-rules/15-frontend-design.md`
+5. **既存資産**: `ui/lib/api/client.ts`, `ui/components/feedback/*`（`ui/Ph3/01` で実装済み）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `ui/lib/api/balances.ts` | `useMonthlyBalances({from, to})` フック（react-query） |
+| `ui/components/charts/MonthlyTrendChart.tsx` | recharts `LineChart`（Client Component） |
+| `ui/components/charts/PeriodFilter.tsx` | 直近12か月 / 全期間 / カスタム |
+| `ui/app/balances/page.tsx` | 残高ページ（ヘッダ + フィルタ + チャート） |
+| `ui/components/charts/__tests__/MonthlyTrendChart.test.tsx` | Render + 空状態 + データ反映 |
+| `ui/app/balances/__tests__/page.test.tsx` | MSW モックでの統合 Render |
+
+## 実装方針
+
+1. **空状態 UI**: 原典 (c)「データ無し時に空状態 UI」を `ui/Ph3/01` の `EmptyState` で実装。
+2. **期間フィルタの URL 同期**: `?from=YYYY-MM&to=YYYY-MM` を Next.js `searchParams` で同期、ブックマーク可能に。
+3. **アクセシビリティ**: チャートに `aria-label` / `role="img"` + 数値テーブル併設（スクリーンリーダ対応）。
+4. **凡例**: 全口座合計のみ。口座別の重ね描画は Phase 4 以降。
+5. **Server / Client Component**: `page.tsx` は Server、データ取得は `useMonthlyBalances` フック → `"use client"` のチャートコンポーネントに渡す。
+6. **金額整形**: `Intl.NumberFormat('ja-JP', {style: 'currency', currency: 'JPY'})` で軸ラベル整形。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `MonthlyTrendChart.test.tsx`：
+  - `test_renders_line_chart_with_data()`：期待データで折れ線が描画
+  - `test_shows_empty_state_when_no_data()`：データ空で `EmptyState` 表示
+  - `test_chart_has_accessible_label()`：`aria-label` を持つ
+  - `test_y_axis_formats_currency_jpy()`
+- `page.test.tsx`（MSW）：
+  - `test_renders_12_months_default()`
+  - `test_period_filter_updates_url_search_params()`：フィルタ変更で URL に反映
+
+### 2. Green
+
+1. `ui/lib/api/balances.ts` で `useMonthlyBalances` フック実装（react-query + fetch ラッパ）
+2. `ui/components/charts/MonthlyTrendChart.tsx` で recharts `LineChart` 実装、`"use client"`
+3. `ui/components/charts/PeriodFilter.tsx` で期間選択 UI
+4. `ui/app/balances/page.tsx` でフィルタ + チャート統合、`searchParams` 連携
+
+### 3. Refactor
+
+- 通貨整形を `ui/lib/format/currency.ts` に共通化（`03 / 04` でも再利用予定）
+- 期間プリセット（直近 6 か月 / 12 か月 / 全期間）を定数化
+
+## 受入条件
+
+原典 §4.3 Phase 3.3 受入基準：
+- `GET /api/balances/monthly` の結果を折れ線で描画
+- 期間フィルタ（直近12か月 / 全期間）が動作
+- データ無し時に空状態 UI
+
+加えて：
+- recharts の SSR/CSR 互換性確認（`"use client"` 配下で正常）
+- 月数 1〜120 で正常描画
+- 巨大データ（120 か月）で描画 1 秒以内
+- `aria-label` で「YYYY年MM月の全口座合計残高: ¥XXX」の要約が読める
+- `tsc --strict` クリーン
+
+## 品質ゲート
+
+```bash
+cd ui
+npm run test -- balances MonthlyTrendChart
+npm run typecheck
+npm run lint
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/monthly-trend-chart`
+- コミット粒度（最低 4 件）：
+  1. `テスト: 月次推移チャート・期間フィルタ・空状態のテストを先行作成`
+  2. `機能: useMonthlyBalances フックとAPIラッパを実装`
+  3. `機能: MonthlyTrendChart コンポーネントとアクセシビリティ対応を実装`
+  4. `機能: balances ページに期間フィルタとチャートを統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.3 月次推移グラフを実装。
+
+## 成果物
+- ui/lib/api/balances.ts
+- ui/components/charts/{MonthlyTrendChart,PeriodFilter}.tsx
+- ui/app/balances/page.tsx
+- 各 __tests__/
+
+## 検証結果
+- npm run test / typecheck / lint: 全件緑
+- 描画パフォーマンス: 120ヶ月データで < 1秒
+
+## 次のアクション提案
+ui/Ph3/03 (カテゴリ別) / 04 (ポートフォリオ) と並行で進行可能。
+```
+
+## 注意事項
+
+- **recharts は Client Component 必須**（`"use client"` ディレクティブを忘れない）。
+- **searchParams の hydration mismatch** に注意：Server Component で読んだ searchParams を Client に渡すパターンを踏襲。
+- **空配列レスポンス**は API 側（`api/Ph3/02`）で `200 + {data: []}` を返す前提。
+- **凡例・色**: `agent-rules/15-frontend-design.md` のアクセント色に合わせる。`recharts` の既定パステルは使わない。

--- a/docs/plans/ui/Ph3/03-category-spending-view.md
+++ b/docs/plans/ui/Ph3/03-category-spending-view.md
@@ -1,0 +1,148 @@
+---
+title: ui/Ph3/03 カテゴリ別支出ビュー
+service: ui
+phase_task_id: 3.4
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.4（行 345-355）
+branch: feature/category-spending-view
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/03 カテゴリ別支出ビュー（Phase 3.4）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.4 を `ui` サービス担当の指示書として展開。月別カテゴリ別支出を **積み上げ棒グラフ + 表**で表示し、親カテゴリ → 子カテゴリのドリルダウン操作を提供する。
+
+## 担当サービス
+
+`compose.yml` `ui` サービス。`ui/app/categories/` にカテゴリ支出ページを追加。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `ui/Ph3/01`（雛形）+ `api/Ph3/02`（`/api/categories/spending`） |
+| 下流 | `ui/Ph3/06`（Playwright e2e） |
+
+`ui/Ph3/02 / 04 / 05` と並列着手可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.4（行 345-355）
+2. **分類設計**: `worker/docs/design/03-categorization-engine.md`
+3. **ADR**: `docs/adr/008-three-tier-categorization.md`（カテゴリ分類3層戦略）
+4. **API 仕様**: `api/Ph3/02-aggregation-endpoints.md` の `/api/categories/spending`
+5. **既存資産**: `ui/Ph3/01` の基盤、`ui/Ph3/02` で共通化される `ui/lib/format/currency.ts`
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `ui/lib/api/categories.ts` | `useCategorySpending({month})`, `useCategoryDrilldown({parent_id, month})` |
+| `ui/components/charts/CategoryStackedBar.tsx` | 積み上げ棒グラフ（recharts `BarChart` + `Bar` 複数） |
+| `ui/components/tables/CategorySpendingTable.tsx` | 表（クリックで子展開） |
+| `ui/components/MonthSelector.tsx` | 月選択 |
+| `ui/app/categories/page.tsx` | カテゴリページ |
+| 各 `__tests__/` | Render + ドリルダウン + 未分類表示 |
+
+## 実装方針
+
+1. **ドリルダウン**: 親カテゴリクリックで子カテゴリ展開、`useState` で展開状態管理。子カテゴリは別 API コール（`?parent_id=`）または初回レスポンスに含める（**Planner 推奨：初回レスポンスに `has_children` のみ含め、展開時に追加 API 呼出**でデータ量制御）。
+2. **未分類表示**: `category_id === null` を `null_category` キーで API から受領、UI で `未分類` ラベル + 警告色（`agent-rules/15-frontend-design.md` のアクセント色）で強調。
+3. **空状態**: データなしの月は `EmptyState`。
+4. **金額整形**: `ui/lib/format/currency.ts`（`02` で共通化済）を再利用。
+5. **積み上げの安定性**: カテゴリ順序を「金額降順」固定（月ごとに順序が変わらないように親カテゴリ ID で安定ソート）。
+6. **Server / Client Component**: `page.tsx` は Server、状態管理を含むテーブル / チャートは `"use client"`。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `CategoryStackedBar.test.tsx`:
+  - `test_renders_stacked_bar_with_parent_categories()`
+  - `test_uncategorized_shown_with_warning_color()`
+  - `test_chart_has_accessible_label()`
+- `CategorySpendingTable.test.tsx`:
+  - `test_clicking_parent_drills_down_to_subcategories()`
+  - `test_drilldown_state_resets_on_month_change()`
+  - `test_subtotal_matches_parent_amount()`：親合計と子合計が一致
+- `page.test.tsx`:
+  - `test_month_selector_changes_data()`
+  - `test_empty_state_when_no_data()`
+
+### 2. Green
+
+1. `ui/lib/api/categories.ts` で `useCategorySpending` / `useCategoryDrilldown` 実装
+2. `ui/components/charts/CategoryStackedBar.tsx` 実装
+3. `ui/components/tables/CategorySpendingTable.tsx` 実装（行クリックで子展開）
+4. `ui/components/MonthSelector.tsx` 実装
+5. `ui/app/categories/page.tsx` で統合
+
+### 3. Refactor
+
+- 月選択ロジックを `ui/lib/hooks/useMonthParam.ts` に共通化（`02` の期間フィルタとパターン整合）
+- カラーパレットを `ui/lib/theme/category-colors.ts` に集約
+
+## 受入条件
+
+原典 §4.3 Phase 3.4 受入基準：
+- 月選択で対象月のカテゴリ別合計が表示
+- 親カテゴリでドリルダウン → 子カテゴリ表示
+- 未分類取引が `未分類` として可視化
+
+加えて：
+- 親展開状態が次の月選択でリセット
+- ドリルダウン中に親カテゴリ合計と子カテゴリ合計が一致
+- カテゴリ順序が月をまたいで安定（親 ID 順 + 金額降順）
+- `tsc --strict` クリーン
+
+## 品質ゲート
+
+```bash
+cd ui
+npm run test -- categories
+npm run typecheck
+npm run lint
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/category-spending-view`
+- コミット粒度（最低 4 件）：
+  1. `テスト: カテゴリ別支出ビュー・ドリルダウン・未分類表示のテストを先行作成`
+  2. `機能: useCategorySpending / useCategoryDrilldown フックを実装`
+  3. `機能: 積み上げ棒グラフとカテゴリ表（ドリルダウン対応）を実装`
+  4. `機能: categories ページに月選択とビューを統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.4 カテゴリ別支出ビューを実装。
+
+## 成果物
+- ui/lib/api/categories.ts
+- ui/components/charts/CategoryStackedBar.tsx
+- ui/components/tables/CategorySpendingTable.tsx
+- ui/components/MonthSelector.tsx
+- ui/app/categories/page.tsx
+- 各 __tests__/
+
+## 検証結果
+- npm run test / typecheck / lint: 全件緑
+- 親 / 子合計の一致確認
+
+## 次のアクション提案
+ui/Ph3/02 / 04 / 05 と並行可能、すべて完了で ui/Ph3/06 へ。
+```
+
+## 注意事項
+
+- **金額は API から `Decimal` 文字列**で受領 → UI で `Intl.NumberFormat` 整形（`float` 経由しない）。
+- **`null_category` キーの API レスポンス**: `api/Ph3/02` の仕様と整合。`category_id === null` の表記は `未分類`（i18n は Phase 4 以降）。
+- **ドリルダウンのアクセシビリティ**: 行クリックは `<button>` または `role="button"` + キーボード（Enter/Space）対応。
+- **積み上げの色割当**: 親カテゴリの色をベースに、子カテゴリは明度違いで派生（HSL ベース）。`recharts` の既定色は使わない。

--- a/docs/plans/ui/Ph3/04-portfolio-view.md
+++ b/docs/plans/ui/Ph3/04-portfolio-view.md
@@ -1,0 +1,153 @@
+---
+title: ui/Ph3/04 ポートフォリオ構成ビュー
+service: ui
+phase_task_id: 3.5
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.5（行 357-365）
+branch: feature/portfolio-view
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/04 ポートフォリオ構成ビュー（Phase 3.5）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.5 を `ui` サービス担当の指示書として展開。`holdings` から銘柄種別ごとの構成比を **円グラフ**で表示し、評価額 NULL の銘柄を警告アイコン付きで列挙する。
+
+## 担当サービス
+
+`compose.yml` `ui` サービス。`ui/app/portfolio/` にポートフォリオページを追加。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `ui/Ph3/01`（雛形）+ `api/Ph3/02`（`/api/holdings/composition`） |
+| 下流 | `ui/Ph3/06`（Playwright e2e） |
+
+`ui/Ph3/02 / 03 / 05` と並列着手可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.5（行 357-365）
+2. **データモデル**: `postgres/docs/design/01-data-model.md`（`holdings` の `symbol_kind`, `balance_snapshots`）
+3. **API 仕様**: `api/Ph3/02-aggregation-endpoints.md` の `/api/holdings/composition`
+4. **既存資産**: `ui/Ph3/01` の基盤、`src/kakeibo/domain/holding.py` の `SymbolKind` 列挙（Phase 1.2）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `ui/lib/api/portfolio.ts` | `useHoldingComposition()` |
+| `ui/lib/portfolio/composition.ts` | 構成比計算・NULL 警告分離（純関数） |
+| `ui/components/charts/PortfolioPieChart.tsx` | recharts `PieChart`（Client Component） |
+| `ui/components/portfolio/HoldingWarnings.tsx` | 評価額 NULL 銘柄リスト |
+| `ui/components/portfolio/SnapshotDate.tsx` | 直近スナップショット日付表示 |
+| `ui/app/portfolio/page.tsx` | ポートフォリオページ |
+| 各 `__tests__/` | 構成比計算 + 警告 + 空状態 |
+
+## 実装方針
+
+1. **構成比計算は API + UI 双方でテスト**: API 側で計算済みだが、UI 側のロジック（％表示・色割当）は単体テスト対象（`composition.ts`）。
+2. **NULL 銘柄**: 別領域に列挙、警告アイコン + 「最終取得日: YYYY-MM-DD」表示。`/api/holdings/composition` の `warnings` フィールドをそのまま展開。
+3. **`symbol_kind` の表記**: `src/kakeibo/domain/holding.py` の `SymbolKind`（`stock` / `fund` / `etf` / `crypto` / `cash`）と整合。日本語表示は `stock` → `株式` のような変換を `ui/lib/portfolio/labels.ts` に集約。
+4. **色割当**: `symbol_kind` 別に固定色（再描画で色が変わらないよう `colors[symbol_kind]` で参照）。`recharts` の自動配色は使わない。
+5. **Server / Client Component**: `page.tsx` は Server、`PieChart` は `"use client"`。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `composition.test.ts`：
+  - `test_calculates_total_value_excluding_nulls()`
+  - `test_separates_null_value_holdings_into_warnings()`
+  - `test_ratio_sums_to_one_excluding_nulls()`
+  - `test_handles_empty_holdings()`
+- `PortfolioPieChart.test.tsx`：
+  - `test_renders_pie_segments_per_symbol_kind()`
+  - `test_pie_chart_has_accessible_label()`
+  - `test_segment_colors_consistent_across_renders()`
+- `HoldingWarnings.test.tsx`：
+  - `test_lists_null_value_holdings_with_last_seen()`
+  - `test_empty_when_no_warnings()`
+- `page.test.tsx`：
+  - `test_snapshot_date_displayed()`
+  - `test_empty_state_when_no_holdings()`
+
+### 2. Green
+
+1. `ui/lib/portfolio/composition.ts`（純関数）を実装
+2. `ui/lib/portfolio/labels.ts` で `symbol_kind` → 日本語ラベル変換
+3. `ui/lib/api/portfolio.ts` で `useHoldingComposition` 実装
+4. `ui/components/charts/PortfolioPieChart.tsx` を実装
+5. `ui/components/portfolio/{HoldingWarnings,SnapshotDate}.tsx` を実装
+6. `ui/app/portfolio/page.tsx` で統合
+
+### 3. Refactor
+
+- `composition.ts` を純関数で完全に切り離し（テスト容易性）
+- 色定義を `ui/lib/theme/portfolio-colors.ts` に集約
+
+## 受入条件
+
+原典 §4.3 Phase 3.5 受入基準：
+- `symbol_kind` 別構成比が表示
+- 評価額 NULL の銘柄は警告アイコン付きで列挙
+- 直近スナップショット日付が画面に明示
+
+加えて：
+- 評価額合計と各セグメントの合計が一致
+- スナップショット日付が「YYYY年MM月DD日」形式
+- `symbol_kind` 別の色が一貫（再描画で色変わらない）
+- 構成比 % の小数 1 桁表示（端数誤差調整は最大セグメントに寄せる）
+- `tsc --strict` クリーン
+
+## 品質ゲート
+
+```bash
+cd ui
+npm run test -- portfolio
+npm run typecheck
+npm run lint
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/portfolio-view`
+- コミット粒度（最低 4 件）：
+  1. `テスト: ポートフォリオ円グラフ・構成比計算・NULL警告のテストを先行作成`
+  2. `機能: 構成比計算ロジック（純関数）を実装`
+  3. `機能: PortfolioPieChart と警告コンポーネントを実装`
+  4. `機能: portfolio ページにスナップショット日付とビューを統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.5 ポートフォリオ構成ビューを実装。
+
+## 成果物
+- ui/lib/api/portfolio.ts
+- ui/lib/portfolio/{composition,labels}.ts
+- ui/components/charts/PortfolioPieChart.tsx
+- ui/components/portfolio/{HoldingWarnings,SnapshotDate}.tsx
+- ui/app/portfolio/page.tsx
+- 各 __tests__/
+
+## 検証結果
+- npm run test / typecheck / lint: 全件緑
+- 構成比合計 = 100%（NULL除外）
+
+## 次のアクション提案
+ui/Ph3/02 / 03 / 05 と並行可能、すべて完了で ui/Ph3/06 へ。
+```
+
+## 注意事項
+
+- **`symbol_kind` の文字列定義**: `src/kakeibo/domain/holding.py` と一致させる（Coder は当該ファイルを Read）。
+- **NULL 警告の最終取得日**: API から返る `last_seen` をそのまま表示、UI で計算しない。
+- **円グラフのラベル**: 大きいセグメント（10% 以上）はチャート内、小さいセグメントは凡例に逃がす（`recharts` の `Label` プロパティ調整）。
+- **アクセシビリティ**: 円グラフは視覚情報のみだと読み上げられないので、隣接して銘柄種別 / 金額 / 構成比のテーブルを併設（`role="img"` + `aria-label` + 詳細はテーブル）。

--- a/docs/plans/ui/Ph3/05-rule-editor-ui.md
+++ b/docs/plans/ui/Ph3/05-rule-editor-ui.md
@@ -1,0 +1,207 @@
+---
+title: ui/Ph3/05 ルール編集UI
+service: ui
+phase_task_id: 3.6
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.3 Phase 3.6（行 367-377）
+branch: feature/rule-editor-ui
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/05 ルール編集UI（Phase 3.6 主担当）
+
+## このファイルの位置付け
+
+原典 §4.3 Phase 3.6 を `ui` サービス担当の指示書として展開。`categorization_rules` の CRUD と **ドラッグ並び替え + dry-run プレビュー**を提供する UI。Phase3 完了条件 (c)「UI からルール CRUD」を直接満たす。
+
+## 担当サービス
+
+`compose.yml` `ui` サービス。`ui/app/rules/` にルール一覧と編集ページを追加。`api/Ph3/01` の Rule CRUD と `api/Ph3/03` の dry-run を呼び出す。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `ui/Ph3/01`（雛形）+ `api/Ph3/01`（Rule CRUD）+ `api/Ph3/03`（dry-run） |
+| 下流 | `ui/Ph3/06`（Playwright e2e） |
+
+`ui/Ph3/02 / 03 / 04` と並列着手可能（独立ファイル）。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.3 Phase 3.6（行 367-377）
+2. **分類設計**: `worker/docs/design/03-categorization-engine.md`
+3. **ADR**: `docs/adr/008-three-tier-categorization.md`
+4. **API 仕様**: `api/Ph3/01-flask-rest-api.md` の Rule CRUD、`api/Ph3/03-rule-dry-run-endpoint.md` の dry-run
+5. **リスク**: `docs/plans/01-development-plan.md` §9 R-09（ReDoS）
+6. **既存資産**: `ui/Ph3/01` の基盤
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `ui/package.json` | `@dnd-kit/core@^6`, `@dnd-kit/sortable@^8`, `react-hook-form@^7`, `@hookform/resolvers@^3` を追加 |
+| `ui/lib/api/rules.ts` | `useRules()`, `useCreateRule()`, `useUpdateRule()`, `useDeleteRule()`, `useDryRunRule()`, `useReorderRules()` |
+| `ui/components/rules/RuleForm.tsx` | フォーム（match_field / match_type / pattern / category_id） |
+| `ui/components/rules/RulePreview.tsx` | dry-run 結果プレビュー（debounce 500ms） |
+| `ui/components/rules/RuleList.tsx` | dnd-kit ソート可能リスト |
+| `ui/components/rules/RuleDragHandle.tsx` | ドラッグハンドル（accessibility 対応） |
+| `ui/components/rules/ApplyToExistingDialog.tsx` | 「既存取引に適用しますか？」モーダル |
+| `ui/app/rules/page.tsx` | ルール一覧 |
+| `ui/app/rules/[id]/page.tsx` | ルール編集 |
+| `ui/app/rules/new/page.tsx` | ルール新規作成 |
+| 各 `__tests__/` | フォームバリデーション・ドラッグ並び替え・dry-run プレビュー |
+
+## 実装方針
+
+### 1. ドラッグ並び替え: `@dnd-kit`
+
+- `@dnd-kit/core` + `@dnd-kit/sortable` を採用
+- `react-beautiful-dnd` は **メンテナンス停止状態のため不採用**
+- キーボード操作対応（Tab → Space で持ち上げ → 矢印で移動 → Space で確定）
+
+### 2. フォームバリデーション: `react-hook-form` + `zod`
+
+- 各フィールドの `zod` スキーマで client / server 両側バリデーション
+- `match_type='regex'` の場合、UI 側で **簡易構文チェック**（pattern 長 500 字以下）
+- **ReDoS 検出は API 側の責務**（`api/Ph3/03` の `safe_regex` で SIGALRM タイムアウト）。UI は AbortController でフェイルセーフ。
+
+### 3. dry-run プレビュー（debounce 500ms）
+
+- フォーム入力時に debounce 500ms で `POST /api/rules/dry-run`
+- レスポンスの `matched_count` と `sample` を `RulePreview` に表示
+- API タイムアウト時は「プレビュー取得失敗（パターンを見直してください）」を表示
+
+### 4. 保存後の既存取引への再分類
+
+- 保存成功後 `ApplyToExistingDialog` を表示し、ユーザが Yes なら API（`api/Ph3/01` の Rule CRUD に `?apply_to_existing=true`）で再分類
+- 原典 §4.3 Phase 3.6 受入基準には明示されていないが、ルール作成の運用上必須
+- Phase 4.2 半自動学習との接合点（Phase 4 で本機能を拡張）
+
+### 5. 優先度: 自動採番 + 手動編集
+
+- 保存時に `priority` 値を自動採番（リスト順 × 10、例: 10, 20, 30）
+- ドラッグ並び替え時は隣接値の中点を割り当て（10, 15, 20）、衝突したら全体再採番
+
+### 6. Server / Client Component
+
+- 一覧ページの初期データは Server Component で取得、ソート操作含むインタラクションは `"use client"`
+
+## 依存パッケージ追加
+
+`ui/package.json` runtime:
+- `@dnd-kit/core@^6`
+- `@dnd-kit/sortable@^8`
+- `@dnd-kit/utilities@^3`
+- `react-hook-form@^7`
+- `@hookform/resolvers@^3`
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `RuleForm.test.tsx`:
+  - `test_validates_required_fields()`
+  - `test_regex_pattern_too_long_shows_warning()`：500 文字超で警告表示
+  - `test_invalid_match_type_shows_error()`
+- `RulePreview.test.tsx`:
+  - `test_dry_run_called_on_input_with_debounce()`：500ms debounce 検証
+  - `test_shows_matched_count_and_sample()`
+  - `test_handles_dry_run_timeout_error()`
+- `RuleList.test.tsx`:
+  - `test_drag_reorder_updates_priority()`
+  - `test_keyboard_drag_reorder_works()`：Space + 矢印 で移動
+  - `test_priority_collision_triggers_renumber()`
+- `ApplyToExistingDialog.test.tsx`:
+  - `test_yes_triggers_apply_to_existing_api_call()`
+  - `test_no_skips_apply()`
+- `page.test.tsx`:
+  - `test_delete_rule_requires_confirmation()`
+  - `test_delete_with_confirmation_calls_api()`
+
+### 2. Green
+
+1. `ui/package.json` に依存追加 → `npm install`
+2. `ui/lib/api/rules.ts` で各フックを実装
+3. `ui/components/rules/RuleForm.tsx` で `react-hook-form` + `zod` 実装
+4. `ui/components/rules/RulePreview.tsx` で debounce + dry-run 呼出
+5. `ui/components/rules/RuleList.tsx` で `@dnd-kit` ベースソート
+6. `ui/components/rules/RuleDragHandle.tsx` でアクセシブルなハンドル
+7. `ui/components/rules/ApplyToExistingDialog.tsx` で確認モーダル
+8. `ui/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}` で統合
+
+### 3. Refactor
+
+- debounce ロジックを `ui/lib/hooks/useDebouncedValue.ts` に共通化
+- dnd-kit のセンサー設定（`PointerSensor`, `KeyboardSensor`）を `ui/components/rules/_dnd.ts` に集約
+- 優先度再採番ロジックを `ui/lib/rules/priority.ts` に純関数化（テスト容易性）
+
+## 受入条件
+
+原典 §4.3 Phase 3.6 受入基準：
+- regex / contains / exact のいずれかを選択して保存可能
+- ドラッグで優先度並び替え可能
+- 既存取引へのプレビュー（このルールならN件マッチ）が表示
+- バックエンドの dry-run エンドポイントを利用
+
+加えて：
+- **キーボード操作で並び替え可能**（accessibility）
+- 優先度衝突時に自動再採番
+- ReDoS 警告 / API タイムアウト時の UI フォールバック
+- 削除操作に確認ダイアログ
+- `tsc --strict` クリーン
+
+## 品質ゲート
+
+```bash
+cd ui
+npm run test -- rules
+npm run typecheck
+npm run lint
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/rule-editor-ui`
+- コミット粒度（最低 7 件）：
+  1. `テスト: ルール編集UI・dry-runプレビュー・並び替え・キーボード操作のテストを先行作成`
+  2. `設定: dnd-kit と react-hook-form を導入`
+  3. `機能: useRules / useDryRunRule / useReorderRules フックを実装`
+  4. `機能: RuleForm（zodバリデーション + dry-runプレビュー）を実装`
+  5. `機能: RuleList（dnd-kit並び替え + キーボード対応）を実装`
+  6. `機能: rules ページとルール編集ページを統合`
+  7. `機能: 既存取引への適用確認モーダルを実装`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3.6 ルール編集UI を実装。
+
+## 成果物
+- ui/package.json（dnd-kit / react-hook-form 追加）
+- ui/lib/api/rules.ts
+- ui/components/rules/{RuleForm,RuleList,RulePreview,RuleDragHandle,ApplyToExistingDialog}.tsx
+- ui/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}
+- 各 __tests__/
+
+## 検証結果
+- npm run test / typecheck / lint: 全件緑
+- キーボード並び替え動作確認
+- ReDoS パターンでも UI がフリーズしない
+
+## 次のアクション提案
+ui/Ph3/02-04 完了後 ui/Ph3/06 (Playwright e2e) へ。
+```
+
+## 注意事項
+
+- **`@dnd-kit` のキーボード操作**: `KeyboardSensor` を必ず登録。Tab → Space → 矢印 → Space のフローで accessible に。
+- **dry-run の debounce**: 500ms は経験的閾値。短すぎると API 負荷、長すぎると UX 劣化。`useDebouncedValue` で集約。
+- **API タイムアウト時の UI**: `fetch` の `AbortController` + 5 秒タイムアウト。`api/Ph3/03` のサーバ側 500ms タイムアウトより十分長く設定し、ネットワーク遅延を許容。
+- **優先度の自動採番**: 中点割当が連続すると数値が縮退する（例: 10 → 15 → 12.5 → 11.25）ので、5 回程度の挿入で全体再採番（10, 20, 30, ...）するヘルパを `priority.ts` に実装。
+- **削除時の確認ダイアログ**: 原典に明示なしだが、UX 上必須。Phase 4 でリストア機能（ソフトデリート）を入れる場合は ADR で再評価。
+- **`@dnd-kit` の Server Component 互換**: dnd-kit は client only、ページ全体ではなく操作領域のみ `"use client"` でラップ。

--- a/docs/plans/ui/Ph3/06-e2e-playwright.md
+++ b/docs/plans/ui/Ph3/06-e2e-playwright.md
@@ -1,0 +1,210 @@
+---
+title: ui/Ph3/06 Playwright e2e（Phase 3 完了条件 (d) 横断）
+service: ui
+phase_task_id: 3-completion
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §3.3 完了条件 (d)
+branch: feature/playwright-e2e
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# ui/Ph3/06 Playwright e2e（Phase 3 完了条件 (d) 横断）
+
+## このファイルの位置付け
+
+原典 §3.3 完了条件 (d)「Playwright e2e で主要シナリオが緑」を満たす **横断タスク**。`ui/Ph3/02〜05` 完了後の Phase 3 最終検証。
+
+## 担当サービス
+
+`ui` サービスをエンドツーエンドで叩く e2e テスト。配置はリポジトリルート `tests/e2e/`（既存 `tests/unit/`, `tests/integration/` と並列、`agent-rules/11-testing-strategy.md` のテスト階層と整合）。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `ui/Ph3/02 / 03 / 04 / 05` 全完了 |
+| 下流 | なし（Phase 3 完了の最終検証） |
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §3.3 完了条件 (d)
+2. **テスト戦略**: `agent-rules/11-testing-strategy.md` §テスト階層
+3. **デプロイ**: `docs/design/04-deployment-stack.md`
+4. **既存資産**:
+   - Phase 1.6 の取込CLI（`python -m kakeibo.ingest`）でフィクスチャ投入
+   - Phase 1.4 / 1.5 の MUFG / SMBC ゴールデンマスタ CSV
+   - `compose.yml` の api / ui / postgres スタック
+   - `ui/Ph3/01〜05` で実装された画面群
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `playwright.config.ts` | Playwright 設定（webServer / projects / use） |
+| `package.json` または `Makefile` | `make e2e` / `npm run e2e` ターゲット |
+| `tests/e2e/fixtures/seed.py` | 既知データ投入スクリプト |
+| `tests/e2e/fixtures/mufg_known.csv` | 既知の MUFG CSV（合成データ） |
+| `tests/e2e/fixtures/smbc_known.csv` | 既知の SMBC CSV |
+| `tests/e2e/balances.spec.ts` | 月次推移グラフが描画される |
+| `tests/e2e/categories.spec.ts` | カテゴリ別支出のドリルダウン |
+| `tests/e2e/portfolio.spec.ts` | ポートフォリオ表示 |
+| `tests/e2e/rules.spec.ts` | ルール作成 → dry-run → 保存 → 並び替え |
+| `tests/e2e/.gitignore` | `results/`, `report/`, `test-results/` |
+
+## 実装方針
+
+### 1. テスト配置
+
+- **リポジトリルート `tests/e2e/`**（`ui/` ディレクトリ内に置かない）
+- 理由: `ui/Dockerfile` の COPY 範囲を不必要に拡大しない、Python 系テスト（`tests/unit/`, `tests/integration/`）と階層整合
+
+### 2. ブラウザ
+
+- **Chromium のみ**（家庭内 NAS 用途で複数ブラウザ検証の必要性低）
+- バイナリは開発時 `npx playwright install chromium`、CI は Phase 4.6 で考慮
+
+### 3. 環境
+
+- **`docker compose up -d`** で api / ui / postgres を起動した状態で実行
+- 認証は **`KAKEIBO_API_AUTH_BYPASS=1`** で無効化（`api/Ph3/01` の dev バイパス）
+- 本番想定の Caddy 経路は **Phase 3 では検証しない**（Phase 4.6 リリース時に手動検証）
+
+### 4. データ投入: `tests/e2e/fixtures/seed.py`
+
+- pytest 系から既存の取込CLIを呼び出し、既知データを decisive に投入
+- 各 spec の `beforeAll` で `python -m kakeibo.ingest mufg tests/e2e/fixtures/mufg_known.csv` を実行
+- DB 状態をリセットするクリーンアップは Playwright `globalTeardown` で `TRUNCATE` 実行
+
+### 5. webServer 設定
+
+`playwright.config.ts` で：
+- `webServer.command`: `docker compose up -d`（CI/local 共通）
+- `webServer.url`: `http://localhost:3000`（ui 直）または Caddy 経由 `https://localhost:8443`（自己署名で skipTLS）
+
+開発時の簡易実行は `npm run dev`（ui 単独）も許容。
+
+### 6. 主要 4 シナリオ
+
+#### `balances.spec.ts`
+- 残高ページに遷移 → 月次推移チャートが描画 → 期間フィルタ「直近6か月」に変更 → URL 更新確認
+
+#### `categories.spec.ts`
+- カテゴリページに遷移 → 月選択 → 親カテゴリクリックで子展開 → 子カテゴリ合計が親と一致
+
+#### `portfolio.spec.ts`
+- ポートフォリオページに遷移 → 円グラフ + スナップショット日付表示確認 → NULL 警告の有無
+
+#### `rules.spec.ts`（最も複雑）
+1. ルール一覧ページに遷移
+2. 「新規作成」→ フォーム入力（`match_type=contains`, `pattern=コンビニ`）
+3. dry-run プレビューで「N件マッチ」表示確認
+4. 「保存」→ 一覧に表示
+5. 「既存取引に適用？」モーダルで Yes
+6. 一覧でドラッグ並び替え（最初のルールを最後へ）
+7. ページリロード後も順序維持
+
+### 7. CI 連携
+
+- **本指示書では CI 設定までは扱わず、ローカル `make e2e` で完了**
+- CI 連携は Phase 4.6 リリース時に再評価
+
+## 依存パッケージ追加
+
+`ui/package.json` dev:
+- `@playwright/test@^1.45`
+
+リポジトリルートに `playwright.config.ts` を置くため、`@playwright/test` は ui ディレクトリではなく **リポジトリルート** にも置きたいが、Phase 3 では UI と同居させて `ui/` から実行する形にして簡素化（ファイルパスは `tests/e2e/` 直下、設定は `ui/playwright.config.ts` に置くか root に置くかは Coder 判断、推奨はルート）。
+
+**Planner 推奨**: `playwright.config.ts` をリポジトリルートに置き、`package.json`（`ui/package.json` と並列で root にも `package.json` を置くか、Makefile 経由で `ui/node_modules/.bin/playwright test` を呼ぶ）。本リポジトリにはルート `package.json` がない（`ui/package.json` のみ）ため、Makefile アプローチを採用：
+
+```makefile
+e2e:
+    cd ui && npx playwright test --config=../playwright.config.ts
+```
+
+## 実装手順（TDD: e2e は実装と同時進行）
+
+### 1. Red
+
+- `playwright.config.ts` を最小実装し、`tests/e2e/balances.spec.ts` で `expect(page).toHaveTitle(/家計/)` のような単純テストを書く
+- `npx playwright test` で **環境設定起因の失敗**を確認（webServer / DB seed が未実装で落ちる）
+
+### 2. Green
+
+1. `tests/e2e/fixtures/{mufg,smbc}_known.csv` を Phase 1.4 / 1.5 のゴールデンマスタから流用
+2. `tests/e2e/fixtures/seed.py` で取込CLIを呼び出すヘルパ実装
+3. `playwright.config.ts` で `webServer` + `globalSetup`（seed 実行）+ `globalTeardown`（TRUNCATE）を実装
+4. 各 spec を順に実装（balances → categories → portfolio → rules の順）
+5. `make e2e` で全件緑にする
+
+### 3. Refactor
+
+- 共通の Page Object（`tests/e2e/pages/{BalancesPage,CategoriesPage,...}.ts`）に抽出
+- 認証バイパス設定を `tests/e2e/_setup/auth.ts` に集約
+
+## 受入条件
+
+原典 §3.3 完了条件 (d)：
+- Playwright e2e で主要シナリオが緑
+
+詳細：
+- 主要 4 シナリオ（残高 / カテゴリ / ポートフォリオ / ルール）が緑
+- 実行時間が **5 分以内**（`agent-rules/11-testing-strategy.md` §品質指標 統合 5 分以内に整合）
+- 失敗時にスクリーンショット + trace が `tests/e2e/results/` に保存
+- `make e2e` で全シナリオ実行可能
+
+## 品質ゲート
+
+```bash
+docker compose up -d
+make e2e
+# または
+cd ui && npx playwright test --config=../playwright.config.ts
+docker compose down
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/playwright-e2e`
+- コミット粒度（最低 5 件）：
+  1. `テスト: Playwright設定とfixture投入スクリプトを追加`
+  2. `テスト: 残高月次推移のe2eシナリオを追加`
+  3. `テスト: カテゴリ別支出ドリルダウンのe2eシナリオを追加`
+  4. `テスト: ポートフォリオ表示のe2eシナリオを追加`
+  5. `テスト: ルール作成・dry-run・並び替えのe2eシナリオを追加`
+  6. `設定: Makefile に e2e ターゲットを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 3 完了条件 (d) Playwright e2e を実装。
+
+## 成果物
+- playwright.config.ts
+- tests/e2e/{balances,categories,portfolio,rules}.spec.ts
+- tests/e2e/fixtures/{seed.py, mufg_known.csv, smbc_known.csv}
+- Makefile（e2e ターゲット）
+
+## 検証結果
+- make e2e: 全件緑（X 分）
+- 失敗時のスクショ・trace 保存確認
+
+## Phase 3 完了状況
+完了条件 (a) (b) (c) (d) (e) すべて達成。Phase 4 着手準備が整った。
+
+## 次のアクション提案
+docs/plans/{api,ui,worker}/Ph4/ 配下に Phase 4 タスク指示書を生成する。
+```
+
+## 注意事項
+
+- **Playwright バイナリ**: `npx playwright install` を docker compose 内ではなくホスト側で実行。テストはホストの Chromium が `localhost:3000` を叩く構成（compose 内でブラウザを動かさない）。
+- **`globalSetup` でのデータ投入**: 取込CLIが Phase 1.6 で実装される前提。未完了状態では本タスクは着手不可。
+- **TRUNCATE タイミング**: `globalTeardown` で全 transactions / categories / rules を削除。本番 DB と混在しないようテスト用 DATABASE_URL を別途指定。
+- **認証バイパス**: 本番ビルドで `KAKEIBO_API_AUTH_BYPASS=1` が誤って有効化されないことを `api/Ph3/01` 側で保証済。本タスクでは設定だけ参照。
+- **flaky 対策**: `expect(...).toBeVisible({timeout: 5000})` のような明示タイムアウト + retry を入れる。Playwright の自動 retry は **無効化**（テスト failure を隠さない）。
+- **CI 連携は Phase 4.6 で**: `agent-rules/50-production-reliability.md` 範囲外、Phase 3 完了スコープには含めない。

--- a/docs/plans/ui/Ph3/README.md
+++ b/docs/plans/ui/Ph3/README.md
@@ -1,0 +1,109 @@
+---
+title: ui サービス Phase3 タスク指示書
+service: ui
+phase: 3
+status: Ready
+parent_index: docs/plans/13-phase3-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# ui サービス Phase3 タスク指示書
+
+`compose.yml` `ui` サービス（Next.js 14 App Router、Phase 0 で雛形配備済み）を **本格的な React Dashboard** に拡張する。Phase 3 の主担当はこの ui サービス（5 タスク + e2e 横断 1 タスク）。
+
+## サービス境界（Phase3 で本ディレクトリが扱うもの）
+
+| 範囲 | パス |
+|---|---|
+| Next.js App Router 配下のページ | `ui/app/{balances,categories,portfolio,rules}/page.tsx` 等 |
+| 共通レイアウト・状態コンポーネント | `ui/components/{layout,feedback,charts,tables,rules,portfolio}/` |
+| API クライアント・型生成 | `ui/lib/api/`, `ui/lib/query/` |
+| ロジック（構成比計算など） | `ui/lib/portfolio/` |
+| グローバル CSS・デザイントークン | `ui/styles/` |
+| テスト基盤 | `ui/test/`, `ui/vitest.config.ts` |
+| package.json 依存追加 | `ui/package.json`, `ui/tsconfig.json`, `ui/next.config.mjs` |
+| Playwright e2e | `tests/e2e/`（リポジトリルート、pytest 系と並列） |
+
+### このディレクトリでは扱わないもの
+
+| 対象 | 帰属 |
+|---|---|
+| Flask REST API / OpenAPI | `api/Ph3/01` |
+| 集計エンドポイント（`/api/balances/monthly` 等） | `api/Ph3/02` |
+| ルール dry-run エンドポイント | `api/Ph3/03` |
+| DB スキーマ・取込パイプライン | `postgres/Ph3/`, `worker/Ph3/`（いずれもタスクなし） |
+
+## タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典 | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 3.2 React Dashboard 雛形 | [`01-react-dashboard-scaffold.md`](./01-react-dashboard-scaffold.md) | §4.3 L321-331 | `feature/react-dashboard-scaffold` | 🔴 高 |
+| 02 | Phase 3.3 月次推移グラフ | [`02-monthly-trend-chart.md`](./02-monthly-trend-chart.md) | §4.3 L333-343 | `feature/monthly-trend-chart` | 🟡 中 |
+| 03 | Phase 3.4 カテゴリ別支出ビュー | [`03-category-spending-view.md`](./03-category-spending-view.md) | §4.3 L345-355 | `feature/category-spending-view` | 🟡 中 |
+| 04 | Phase 3.5 ポートフォリオ構成ビュー | [`04-portfolio-view.md`](./04-portfolio-view.md) | §4.3 L357-365 | `feature/portfolio-view` | 🟡 中 |
+| 05 | Phase 3.6 ルール編集UI | [`05-rule-editor-ui.md`](./05-rule-editor-ui.md) | §4.3 L367-377 | `feature/rule-editor-ui` | 🔴 高 |
+| 06 | Phase 3 完了条件 (d) Playwright e2e | [`06-e2e-playwright.md`](./06-e2e-playwright.md) | §3.3 完了条件 (d) | `feature/playwright-e2e` | 🟡 中 |
+
+## 実行順序（推奨）
+
+```
+[Phase 1 / 2 完了] + api/Ph3/01 完了
+   ↓
+ui/Ph3/01 (React 雛形)
+   ├─→ ui/Ph3/02 (月次推移)     ← api/Ph3/02 必要
+   ├─→ ui/Ph3/03 (カテゴリ別)   ← api/Ph3/02 必要
+   ├─→ ui/Ph3/04 (ポートフォリオ) ← api/Ph3/02 必要
+   └─→ ui/Ph3/05 (ルール編集UI)  ← api/Ph3/03 必要
+                                  ↓
+                          ui/Ph3/06 (Playwright e2e)
+```
+
+並列の機会：
+- `ui/Ph3/02 / 03 / 04` は `ui/Ph3/01 + api/Ph3/02` 完了後に **3 並列** 可（異なるページ・コンポーネント）
+- `ui/Ph3/05` は `api/Ph3/03` のみが直接依存、`02-04` と完全並列可
+
+## 共通の前提
+
+- **Phase 1 / 2 完了 + `api/Ph3/01` 完了が必須**
+- `api/Ph3/02` 完了が `ui/Ph3/02-04` の前提
+- `api/Ph3/03` 完了が `ui/Ph3/05` の dry-run プレビューの前提
+- **Next.js 14 App Router 維持**（Vite 移行しない、Phase 0 の Dockerfile / standalone build / healthcheck 互換性確保）
+- 状態管理は `@tanstack/react-query` v5、グラフは `recharts`
+- API 型は OpenAPI から `openapi-typescript` で機械生成
+- フォントは `Noto Sans JP` + 日本語ディスプレイフォント、**Inter / Roboto / system-ui を使用しない**（`agent-rules/15-frontend-design.md`）
+
+## 担当 Worker サブエージェント
+
+`agent-rules/91-claude-subagent-coding.md` に従う。
+
+| Worker | 主な責務 |
+|---|---|
+| Planner | デザイントークン設計、コンポーネント分割、状態管理境界の設計 |
+| Coder | テスト先行（Testing Library / MSW）→ コンポーネント実装。Server / Client Component の使い分け |
+| Reviewer | `agent-rules/15-frontend-design.md` の禁止事項（フォント・配色）チェック、accessibility（キーボード操作・aria-label）、Server Component 制約 |
+| Git-composer | アトミックコミット、`feature/*` ブランチ運用 |
+
+並列ポリシー: `02 / 03 / 04` は同一メッセージで Coder 3体並列起動可。`05` も独立並列可。
+
+## 共通の品質ゲート
+
+```bash
+cd ui
+npm run lint                  # next lint
+npm run test                  # vitest
+npm run build                 # standalone 出力（既存 Dockerfile 互換性確認）
+npx tsc --strict --noEmit     # 型チェック
+```
+
+統合確認（`ui/Ph3/06` 完了後）：
+- Playwright e2e 主要 4 シナリオ（残高 / カテゴリ / ポートフォリオ / ルール）が緑
+- 既存の Python テスト（`tests/unit/test_ui_nextjs.py`）も緑のまま
+
+## Phase3 完了条件カバレッジ（ui 担当範囲）
+
+| 完了条件 | 主担当タスク |
+|---|---|
+| (b) 月次推移 / カテゴリ / ポートフォリオ表示 | `02` + `03` + `04` |
+| (c) UI からルール CRUD | `05` |
+| (d) Playwright e2e 主要シナリオ緑 | `06` |
+| (e) `tsc --strict` クリーン | 全タスク横断 |

--- a/docs/plans/ui/README.md
+++ b/docs/plans/ui/README.md
@@ -1,0 +1,60 @@
+---
+title: ui サービス Phase1 タスク指示書
+service: ui
+phase: 1
+status: NoTasks
+parent_index: docs/plans/10-phase1-overview.md
+last_updated: 2026-05-01
+---
+
+# ui サービス Phase1 タスク指示書
+
+## 結論：Phase1 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `ui` サービス（Next.js / Node.js 20 LTS）は **Phase 0 で雛形が配備済み**。`ui/app/{layout.tsx,page.tsx}` の最小ページが起動するのみで、Phase 1 の MVP（CSV → DB → SQL）には UI が必要ない。
+
+Phase 1 のタスク（1.1〜1.8）はすべて `postgres` または `worker` サービスに帰属する。`docs/plans/10-phase1-overview.md` §2 のタスク一覧で UI を変更する項目は存在しない。
+
+## サービス境界（参考）
+
+| 範囲 | パス |
+|---|---|
+| Next.js アプリ本体 | `ui/app/` |
+| 設定 | `ui/{next.config.mjs, tsconfig.json, package.json, package-lock.json}` |
+| Dockerfile（multi-stage） | `ui/Dockerfile` |
+| .gitignore | `ui/.gitignore` |
+
+## Phase1 の間に ui サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| `ui/package.json` の依存追加 | 原則不要 | Phase 1 では追加しない |
+| `ui/Dockerfile` 変更 | 原則不要 | – |
+| ヘルスチェック挙動の変更 | 不可 | Phase 0 の HEALTHCHECK が他テスト（`tests/unit/test_ui_nextjs.py` 等）と整合していることを維持 |
+
+`agent-rules/00-core-principles.md` の絶対遵守の3原則 §1 デグレッション防止を厳守する。
+
+## Phase 3.2 への申し送り
+
+Phase 3 で本サービスに本格着手するときの起点：
+
+- 原典: `docs/plans/01-development-plan.md` §4.3 Phase 3.2 React Dashboard 雛形
+- ブランチ: `feature/react-dashboard-scaffold`
+- 関連 ADR: ADR-009（NAS + Docker Compose）
+- 関連 design: `docs/design/04-deployment-stack.md`
+- 関連 agent-rules: `agent-rules/15-frontend-design.md`
+- 着手内容（予定）：
+  - Vite + TypeScript + React の構築（Next.js 雛形からの移行 or 併存）
+  - API クライアント（`fetch` ラッパ）
+  - レイアウト整備
+  - vitest + Testing Library 基盤
+
+Phase 3.2 着手時に本ディレクトリへ `01-react-dashboard-scaffold.md` 等の指示書を追加する。
+
+## 担当 Worker サブエージェント
+
+Phase1 期間中は原則不要。
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `tests/unit/test_ui_nextjs.py` 等が `worker`/`postgres` 側のタスクで影響を受けないことを Read のみで確認（プロジェクト共通設定の変更時など） |

--- a/docs/plans/worker/01-domain-types.md
+++ b/docs/plans/worker/01-domain-types.md
@@ -1,0 +1,141 @@
+---
+title: worker/01 ドメイン共通型（Transaction / Holding / BalanceSnapshot）
+service: worker
+phase_task_id: 1.2
+priority: 高
+source_plan: docs/plans/03-phase1-domain-types.md
+branch: feature/domain-types
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/01 ドメイン共通型（Phase 1.2）
+
+## このファイルの位置付け
+
+原典 `docs/plans/03-phase1-domain-types.md` を `worker` サービス担当の実装指示書として再編。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`worker` コンテナ。`src/kakeibo/domain/` 配下の dataclass モジュール群。`api` コンテナも `src/kakeibo` を import するが、Phase1 では参照しない。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `postgres/01`（DB スキーマ） |
+| 下流 | `worker/02`（IngestAdapter ABC） / `worker/06`（ハッシュ冪等性 PBT）から参照 |
+
+## 入力（Coder が読むべきファイル）
+
+1. **原典**: `docs/plans/03-phase1-domain-types.md`（必読）
+2. **データモデル**: `postgres/docs/design/01-data-model.md`
+3. **取込アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+4. **ADR**: `docs/adr/005-numeric-money-type.md`, `docs/adr/006-hash-uniqueness.md`
+5. **既存スケルトン**: `src/kakeibo/domain/__init__.py`（プレースホルダ。本タスクで中身を実装）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/domain/__init__.py` | 公開 API の集約（`Transaction`, `Holding`, `BalanceSnapshot`, `SymbolKind`, `compute_hash`） |
+| `src/kakeibo/domain/transaction.py` | `Transaction` dataclass + `compute_hash` |
+| `src/kakeibo/domain/holding.py` | `Holding` dataclass + `SymbolKind` (StrEnum) |
+| `src/kakeibo/domain/balance_snapshot.py` | `BalanceSnapshot` dataclass |
+| `src/kakeibo/domain/currency.py` | 通貨コードバリデータ（ISO 4217 3 文字英大文字） |
+| `tests/unit/domain/__init__.py` | 新規（パッケージ初期化） |
+| `tests/unit/domain/test_transaction.py` | バリデーション + `compute_hash` 決定性 |
+| `tests/unit/domain/test_holding.py` | `SymbolKind` 範囲 + バリデーション |
+| `tests/unit/domain/test_balance_snapshot.py` | バリデーション |
+| `tests/unit/domain/test_currency.py` | 通貨コードバリデータ |
+
+## 実装方針（原典 §実装方針より要約）
+
+1. **dataclass 第一選択**: `@dataclass(frozen=True, slots=True)` + `__post_init__` で手書きバリデーション。pydantic は使わない（依存縮小）。
+2. **Transaction フィールド**: `account_id: int`, `occurred_on: date`, `occurred_at: datetime | None`, `amount: Decimal`, `currency: str`, `description: str`, `category_id: int | None`, `category_source: Literal['rule','llm','manual'] | None`, `raw_payload: dict[str, Any]`, `hash: str`。
+3. **バリデーション**: `amount is None` → `ValueError`、`len(currency) != 3 or not currency.isalpha() or not currency.isupper()` → `ValueError`、`occurred_on` が `date` でない → `TypeError`。
+4. **`compute_hash`**: `f"{account_id}|{occurred_on.isoformat()}|{amount}|{description}"` を UTF-8 で encode → `hashlib.sha256(...).hexdigest()`。description のトリミングは **行わない**（境界条件は `worker/06` で確定）。
+5. **`SymbolKind`**: `enum.StrEnum` で `STOCK / FUND / ETF / CRYPTO / CASH`（`design/01-data-model.md` と整合）。
+6. **`BalanceSnapshot`**: `account_id`, `as_of_date: date`, `balance: Decimal`, `currency: str`。
+
+## 実装手順（TDD）
+
+### 0. ブランチ作成
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b feature/domain-types
+```
+
+### 1. Red
+
+- `tests/unit/domain/test_transaction.py` に正常系 1 件 + 異常系 7 件以上（`amount=None`, `currency="JP"`, `currency="jpy"`, `currency="JPYY"`, `occurred_on="2026-04-30"` など）。
+- `compute_hash` 決定性: 同一引数 100 回呼んで同一 hex / 引数 1 つ変えると別 hex（`account_id`/`occurred_on`/`amount`/`description` を 1 件ずつ変える）。
+- `tests/unit/domain/test_holding.py` で `SymbolKind` 列挙、未定義値で例外。
+- `tests/unit/domain/test_balance_snapshot.py` で `Decimal` / `date` 強制。
+- `tests/unit/domain/test_currency.py` で通貨コードバリデータの境界。
+- `pytest tests/unit/domain/` で全件落ちることを確認。
+
+### 2. Green
+
+- `currency.py` → `transaction.py` → `holding.py` → `balance_snapshot.py` の順に最小実装。
+- 各実装で対応するテストが緑になることを確認。
+
+### 3. Refactor
+
+- バリデーション共通部分（`_ensure_decimal`, `_ensure_date`）を `currency.py` 隣接の `_validators.py` に抽出するか検討。早すぎる抽象化は避ける。
+
+## 受入条件
+
+- `Transaction.amount` が `Decimal`（`isinstance(tx.amount, Decimal) is True`）
+- `Transaction.occurred_on` が `date`、`occurred_at` が `datetime | None`
+- 異常値で `ValueError` または `TypeError` が発生
+- `compute_hash(1, date(2026,4,30), Decimal("1234.56"), "コンビニ")` が複数回呼んで同じ SHA256 hex
+- `Holding.symbol_kind` に `SymbolKind` 以外を渡すと型エラー（pyright）または実行時エラー
+- `pyright` クリーン、`ruff check` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/domain/    # 全件緑（< 5 秒）
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/domain-types`
+- コミット粒度（最低 5 件）：
+  1. `テスト: ドメイン共通型のバリデーションとcompute_hash決定性テストを先行作成`
+  2. `機能: 通貨コードバリデータとSymbolKind列挙を追加`
+  3. `機能: Transaction共通型とcompute_hash関数を実装`
+  4. `機能: Holding共通型を実装`
+  5. `機能: BalanceSnapshot共通型を実装`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.2 ドメイン共通型を実装。
+
+## 成果物
+- src/kakeibo/domain/{transaction,holding,balance_snapshot,currency}.py
+- tests/unit/domain/test_*.py（4 ファイル）
+
+## 検証結果
+- pytest tests/unit/domain/: 全件緑（X 秒）
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+- description の前後空白の扱いは Phase 1.7（worker/06）で確定する暫定方針。
+
+## 次のアクション提案
+worker/02-ingest-adapter-base.md（Phase 1.3）の着手準備が整った。
+```
+
+## 注意事項
+
+- pydantic を導入しない。依存膨張を避ける（`docs/plans/03-phase1-domain-types.md` §実装方針 1）。
+- `compute_hash` 内で description を strip しない。境界条件は `worker/06` で property-based test として固定する。
+- `hash: str` は dataclass のフィールドだが、`__post_init__` で `compute_hash(...)` を計算してフィールドに設定するか、生成側で渡すかの設計選択がある。原典は明示していないが、**呼び出し側で `compute_hash` を呼んで `hash` を渡す** 方式を採用（不変条件が単純で、テストしやすい）。

--- a/docs/plans/worker/02-ingest-adapter-base.md
+++ b/docs/plans/worker/02-ingest-adapter-base.md
@@ -1,0 +1,130 @@
+---
+title: worker/02 IngestAdapter ABC（取込アダプタ抽象基底）
+service: worker
+phase_task_id: 1.3
+priority: 高
+source_plan: docs/plans/04-phase1-ingest-adapter-base.md
+branch: feature/ingest-adapter-base
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/02 IngestAdapter ABC（Phase 1.3）
+
+## このファイルの位置付け
+
+原典 `docs/plans/04-phase1-ingest-adapter-base.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`worker` コンテナ。`src/kakeibo/adapters/` 配下の抽象基底 + 共通エラー型。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/01`（共通型） |
+| 下流 | `worker/03`（MUFG）, `worker/04`（SMBC）, Phase2 系メール / API アダプタ |
+
+## 入力
+
+1. **原典**: `docs/plans/04-phase1-ingest-adapter-base.md`（必読）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **ADR**: `docs/adr/007-adapter-pattern.md`
+4. **依存型**: `src/kakeibo/domain/`（`worker/01` 完了後の状態）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/__init__.py` | 公開 API（`IngestAdapter`, `AdapterError` など） |
+| `src/kakeibo/adapters/base.py` | `IngestAdapter` ABC + `__init_subclass__` での `source` 検証 |
+| `src/kakeibo/adapters/errors.py` | `AdapterError` 基底 + `EncodingMismatchError`, `ColumnMissingError` 雛形 |
+| `tests/unit/adapters/__init__.py` | 新規 |
+| `tests/unit/adapters/_dummy_adapter.py` | テスト専用ダミーアダプタ |
+| `tests/unit/adapters/test_base.py` | 契約検証 |
+
+## 実装方針（原典 §実装方針より要約）
+
+1. **ABC 定義**: `IngestAdapter(abc.ABC)`。`__init__(self, *, account_id: int)` は ABC 側で具体実装、`self.account_id = account_id`。
+2. **抽象メソッド**: `parse(self, payload) -> Iterable[Transaction]` と `extract_holdings(self, payload) -> Iterable[Holding]`。`payload: bytes | str | dict[str, Any]` Union。
+3. **`source` 強制**: `__init_subclass__(cls, **kwargs)` で `cls.source` の存在と非空文字列を検証。未設定なら `TypeError`。`source: ClassVar[str]` を ABC に宣言。
+4. **`account_id` 注入**: コンストラクタ経由のみ。`parse` 引数に `account_id` を含める / `**context` 拡張は **採用しない**。
+5. **エラー型**: `AdapterError(Exception)` を基底に、`EncodingMismatchError`, `ColumnMissingError` を派生。Phase 1.4/1.5 で送出。
+6. **ダミーアダプタ**: テスト fixture 用。`source = "dummy"`、`parse(payload)` が固定 Transaction を返す。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+`tests/unit/adapters/test_base.py` に以下を記述：
+- 抽象メソッド未実装サブクラスの初期化が `TypeError`
+- `source` 未設定サブクラス定義時に `TypeError`（クラス定義時点で発生）
+- `DummyAdapter()`（`account_id` なし）が `TypeError`、`DummyAdapter(account_id=42).account_id == 42`
+- `DummyAdapter(account_id=42).parse(b"")` が `Iterable[Transaction]` を返し各要素が `Transaction` で `account_id == 42`
+- `extract_holdings(b"")` が空イテラブル
+
+`from kakeibo.adapters.base import IngestAdapter` で ImportError → 落ちることを確認。
+
+### 2. Green
+
+- `src/kakeibo/adapters/errors.py` を最小実装。
+- `src/kakeibo/adapters/base.py` で `IngestAdapter` を実装。`__init_subclass__` 内で `cls.source` 検証。
+- `tests/unit/adapters/_dummy_adapter.py` を実装。
+- 各テストを順に通す。
+
+### 3. Refactor
+
+- `__init_subclass__` 内のバリデーションを `_validate_source(cls)` に抽出可能か検討。
+
+## 受入条件
+
+- `IngestAdapter.__init__(self, *, account_id: int)` を備える
+- `parse` / `extract_holdings` が抽象メソッド
+- `source` 未設定サブクラスは初期化前（クラス定義時）に `TypeError`
+- 抽象メソッド未実装サブクラスのインスタンス化が `TypeError`（Python 標準 `abc` 挙動）
+- `account_id` キーワード引数なしで初期化すると `TypeError`
+- ダミーアダプタが契約を満たす
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/    # 全件緑
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/ingest-adapter-base`
+- コミット粒度（最低 4 件）：
+  1. `テスト: IngestAdapter契約とsource属性必須化のテストを先行作成`
+  2. `機能: AdapterError基底とEncodingMismatchError/ColumnMissingError雛形を追加`
+  3. `機能: IngestAdapter ABCとaccount_id注入・source強制を実装`
+  4. `テスト: テスト用ダミーアダプタを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.3 IngestAdapter ABC を実装。
+
+## 成果物
+- src/kakeibo/adapters/{base.py, errors.py, __init__.py}
+- tests/unit/adapters/{test_base.py, _dummy_adapter.py}
+
+## 検証結果
+- pytest tests/unit/adapters/: 全件緑
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/03 (MUFG) と worker/04 (SMBC) を並列着手可能。
+```
+
+## 注意事項
+
+- `extract_holdings` は銀行アダプタには無関係だが、抽象を保ち各サブクラスで `return ()` を明示する設計を採用（型安全性）。
+- `parse(payload, **context)` のような可変引数注入や `parse(payload, account_id=...)` は **採用禁止**。`account_id` はインスタンス属性経由（原典 §実装方針 3）。
+- `payload` 型 Union に dict を含めることで Phase 2 系のメール / API レスポンスにも対応。

--- a/docs/plans/worker/03-mufg-csv-adapter.md
+++ b/docs/plans/worker/03-mufg-csv-adapter.md
@@ -1,0 +1,136 @@
+---
+title: worker/03 MUFG CSV アダプタ
+service: worker
+phase_task_id: 1.4
+priority: 中
+source_plan: docs/plans/05-phase1-mufg-csv-adapter.md
+branch: feature/adapter-mufg-csv
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/03 MUFG CSV アダプタ（Phase 1.4）
+
+## このファイルの位置付け
+
+原典 `docs/plans/05-phase1-mufg-csv-adapter.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`worker` コンテナ。`src/kakeibo/adapters/mufg.py` + Shift_JIS ゴールデンマスタ fixture。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/02`（IngestAdapter ABC） |
+| 下流 | `worker/05`（取込CLI） |
+
+`worker/04 (SMBC)` と独立並行可能。
+
+## 入力
+
+1. **原典**: `docs/plans/05-phase1-mufg-csv-adapter.md`（必読）
+2. **取込フロー**: `worker/docs/design/08-ingest-flow.md`
+3. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+4. **ADR**: `docs/adr/001-hybrid-ingestion-strategy.md`, `docs/adr/007-adapter-pattern.md`
+5. **リスク**: `docs/plans/01-development-plan.md` §9 R-08（文字コード固定方針）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/mufg.py` | `MufgCsvAdapter` 実装 |
+| `src/kakeibo/adapters/errors.py` | 既存ファイルへの追記（`worker/02` で雛形定義済の場合は流用） |
+| `tests/fixtures/mufg/sample.csv` | Shift_JIS の合成データ（5〜10 行） |
+| `tests/fixtures/mufg/expected.json` | 期待 Transaction リスト（フィールドスナップショット） |
+| `tests/fixtures/mufg/broken_encoding.csv` | UTF-8 で書いたエラーパス用 |
+| `tests/unit/adapters/test_mufg.py` | ゴールデンマスタ + エラーパス + ハッシュ決定性 |
+
+## 実装方針（原典 §実装方針より要約）
+
+1. **クラス**: `MufgCsvAdapter(IngestAdapter)`。`source: ClassVar[str] = "mufg"`。コンストラクタは ABC 由来 `__init__(self, *, account_id: int)` をそのまま使用。追加引数なし。
+2. **デコード**: `payload.decode("shift_jis")` を `try/except UnicodeDecodeError` で囲み、失敗時 `EncodingMismatchError`。**chardet 等の自動判定は使わない**（R-08）。
+3. **CSV 解析**: `csv.DictReader` で行イテレーション。MUFG 列名（`日付`, `摘要`, `お支払金額`, `お預り金額`, `差引残高` 等）を定数化。列欠損で `ColumnMissingError`。
+4. **金額符号**: 出金カラム → `amount = -Decimal(value.replace(",", ""))`、入金カラム → `amount = Decimal(value.replace(",", ""))`。両方空 / 両方ありは不正。
+5. **日付**: `datetime.strptime(row["日付"], "%Y/%m/%d").date()`（実フォーマット要確認、fixture に反映）。
+6. **description**: 摘要をそのまま採用（前後空白除去 **しない**。`worker/06` で確定）。
+7. **ハッシュ**: 共通 `compute_hash(self.account_id, occurred_on, amount, description)` を呼ぶ。本アダプタ内で再実装禁止。
+8. **`extract_holdings`**: 空イテラブル `return ()`。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/mufg/sample.csv` を Shift_JIS で 5〜10 行作成（合成データ。実取引情報は **入れない**）。
+- `tests/fixtures/mufg/expected.json` に期待 Transaction を JSON で記述（`amount` は文字列、`hash` は事前計算した値）。
+- `tests/fixtures/mufg/broken_encoding.csv` を UTF-8 で作成。
+- `tests/unit/adapters/test_mufg.py` で次を網羅：
+  - ゴールデンマスタ完全一致（`dataclasses.asdict` 経由で dict 比較、Decimal は文字列で比較）
+  - 出金 / 入金それぞれの符号
+  - エンコーディング不一致 → `EncodingMismatchError`
+  - 列欠損 → `ColumnMissingError`
+  - 数値パース不能 → `ValueError`（or 専用例外）
+  - 同一 CSV 2 回パースで `Transaction.hash` 一致
+
+### 2. Green
+
+- `MufgCsvAdapter` を最小実装で 1 件抽出から開始。
+- 列マッピング → 符号正規化 → 全件抽出 → エラーパスの順に通す。
+
+### 3. Refactor
+
+- 列名定数 / 金額正規化 (`_normalize_amount`) を private 関数へ抽出。
+
+## 受入条件
+
+- サンプル CSV から `expected.json` の N 件が完全一致で抽出される
+- 出金行 `amount` 負、入金行 `amount` 正
+- `broken_encoding.csv`（UTF-8）で `EncodingMismatchError`
+- 同一 CSV 再パースでハッシュ完全一致
+- 列欠損 CSV で `ColumnMissingError`
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/test_mufg.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/adapter-mufg-csv`
+- コミット粒度（最低 4 件）：
+  1. `テスト: MUFG CSVゴールデンマスタとエラーパスのテストを先行作成`
+  2. `機能: MufgCsvAdapter本体（Shift_JISデコード・列マッピング・符号正規化）を実装`
+  3. `機能: 数値パース・列欠損・エンコーディング例外ハンドリングを追加`
+  4. `テスト: ハッシュ決定性確認テストを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.4 MUFG CSV アダプタを実装。
+
+## 成果物
+- src/kakeibo/adapters/mufg.py
+- tests/fixtures/mufg/{sample.csv, expected.json, broken_encoding.csv}
+- tests/unit/adapters/test_mufg.py
+
+## 検証結果
+- pytest tests/unit/adapters/test_mufg.py: 全件緑
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/04 (SMBC) と並行 or 直列で実施 → worker/05 (CLI) へ。
+```
+
+## 注意事項
+
+- **chardet 等の自動判定は使用禁止**。Shift_JIS 固定（`R-08`）。
+- 摘要の正規化（前後空白 / 全角 → 半角）は **行わない**。Phase 1.7（worker/06）でハッシュ境界条件として確定する。
+- ゴールデンマスタの合成データに **実取引情報を含めない**（`agent-rules/12-security-guidelines.md`）。
+- SMBC アダプタとの抽象化共通化は **行わない**（早すぎる抽象化を避ける、原典 §スコープ「含まない」）。

--- a/docs/plans/worker/04-smbc-csv-adapter.md
+++ b/docs/plans/worker/04-smbc-csv-adapter.md
@@ -1,0 +1,130 @@
+---
+title: worker/04 SMBC CSV アダプタ
+service: worker
+phase_task_id: 1.5
+priority: 中
+source_plan: docs/plans/06-phase1-smbc-csv-adapter.md
+branch: feature/adapter-smbc-csv
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/04 SMBC CSV アダプタ（Phase 1.5）
+
+## このファイルの位置付け
+
+原典 `docs/plans/06-phase1-smbc-csv-adapter.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`worker` コンテナ。`src/kakeibo/adapters/smbc.py` + SMBC 用ゴールデンマスタ fixture。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/02`（IngestAdapter ABC） |
+| 下流 | `worker/05`（取込CLI） |
+
+`worker/03 (MUFG)` と並行可能。`worker/03` を参考実装として参照する。
+
+## 入力
+
+1. **原典**: `docs/plans/06-phase1-smbc-csv-adapter.md`（必読）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **ADR**: `docs/adr/001-hybrid-ingestion-strategy.md`, `docs/adr/007-adapter-pattern.md`
+4. **参考**: `worker/03-mufg-csv-adapter.md`（独立実装だが書き方の参考に）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/smbc.py` | `SmbcCsvAdapter` 実装 |
+| `tests/fixtures/smbc/sample.csv` | SMBC 合成データ |
+| `tests/fixtures/smbc/expected.json` | 期待 Transaction リスト |
+| `tests/unit/adapters/test_smbc.py` | ゴールデンマスタ + 列差分検証 + 摘要正規化 |
+
+## 実装方針（原典 §実装方針より要約）
+
+1. **クラス**: `SmbcCsvAdapter(IngestAdapter)`。`source: ClassVar[str] = "smbc"`。`parse(self, payload: bytes) -> Iterable[Transaction]`。
+2. **エンコーディング**: SMBC は UTF-8 / Shift_JIS のいずれか **固定**。実 CSV を確認して fixtures に反映（自動判定は不可、`R-08`）。
+3. **列マッピング**: SMBC 列名（`年月日`, `お引出し`, `お預入れ`, `お取り扱い内容`, `残高` など）を定数化。MUFG とは別の列名であることを明示。
+4. **摘要正規化**: 全角スペース → 半角スペース or 削除、全角ハイフン → 半角ハイフンなどを `_normalize_description(s: str) -> str` として実装。**Phase 1.7（worker/06）と整合させる**。
+5. **金額符号**: お引出し → 負、お預入れ → 正（MUFG と同じ思想）。
+6. **ハッシュ**: 共通 `compute_hash`。MUFG と同じ呼び出し方式（`self.account_id` 注入）。
+7. **MUFG との独立性**: テスト内で「MUFG の sample.csv を SMBC アダプタに渡すと `ColumnMissingError`」を 1 件記述。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/smbc/sample.csv` を SMBC フォーマットで合成（5〜10 行）。
+- `tests/fixtures/smbc/expected.json` に期待 Transaction を記述。
+- `tests/unit/adapters/test_smbc.py` で次を網羅：
+  - ゴールデンマスタ完全一致
+  - MUFG sample を渡すと `ColumnMissingError`（独立性確認）
+  - 摘要正規化の単体テスト（全角スペース除去 / 全角ハイフン → 半角）
+  - 金額符号（引出 / 預入それぞれ）
+  - 同一 CSV 2 回パースでハッシュ一致
+
+### 2. Green
+
+- 最小実装からゴールデンマスタ全件を通す。
+- `_normalize_description` を最初は素朴な `replace` チェーンで実装。
+- MUFG との共通化は **しない**。
+
+### 3. Refactor
+
+- 列名定数の整理。共通化を急がない（原典 §実装方針 §Refactor の指針：意図的に重複を残し、Phase 2 以降で必要が固まってから抽出）。
+
+## 受入条件
+
+- サンプル CSV から `expected.json` の N 件が抽出される
+- MUFG sample を渡すと `ColumnMissingError`（独立性）
+- 摘要正規化が適用された結果でハッシュが決定的
+- お引出し → 負、お預入れ → 正
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/test_smbc.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/adapter-smbc-csv`
+- コミット粒度（最低 4 件）：
+  1. `テスト: SMBC CSVゴールデンマスタとMUFG入力での独立性確認テストを先行作成`
+  2. `機能: SmbcCsvAdapter本体（列マッピング・摘要正規化）を実装`
+  3. `機能: 引出/預入の符号正規化と例外ハンドリングを追加`
+  4. `テスト: 摘要正規化の単体テストとハッシュ決定性テストを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.5 SMBC CSV アダプタを実装。
+
+## 成果物
+- src/kakeibo/adapters/smbc.py
+- tests/fixtures/smbc/{sample.csv, expected.json}
+- tests/unit/adapters/test_smbc.py
+
+## 検証結果
+- pytest tests/unit/adapters/test_smbc.py: 全件緑
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/03 と worker/04 が揃った時点で worker/05 (取込CLI) に進む。
+```
+
+## 注意事項
+
+- **chardet 等の自動判定は使用禁止**（`R-08`）。
+- MUFG アダプタとの共通化は **行わない**。Phase 1 では別実装で十分（早すぎる抽象化禁止）。
+- 摘要正規化のルールは `worker/06`（ハッシュ境界条件 PBT）と整合する形で固定する。
+- ゴールデンマスタの合成データに実取引情報を含めない。

--- a/docs/plans/worker/05-ingest-cli.md
+++ b/docs/plans/worker/05-ingest-cli.md
@@ -1,0 +1,148 @@
+---
+title: worker/05 取込CLI
+service: worker
+phase_task_id: 1.6
+priority: 高
+source_plan: docs/plans/07-phase1-ingest-cli.md
+branch: feature/ingest-cli
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/05 取込CLI（Phase 1.6）
+
+## このファイルの位置付け
+
+原典 `docs/plans/07-phase1-ingest-cli.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。Phase1 完了条件 (b)「同一 CSV 2 回投入で行数増えず」を直接満たすクリティカルパス上のタスク。
+
+## 担当サービス
+
+`worker` コンテナ。`python -m kakeibo.ingest <institution> <path>` の本体。Phase 2.1 の watchdog Watcher が `subprocess` 経由で叩く前提のため、終了コード規約が固定される。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/03`（MUFG） + `worker/04`（SMBC） |
+| 下流 | `worker/06`（ハッシュ冪等性 PBT）、`worker/07`（月次サマリ）、Phase 2.1 Watcher |
+
+## 入力
+
+1. **原典**: `docs/plans/07-phase1-ingest-cli.md`（必読）
+2. **取込フロー**: `worker/docs/design/08-ingest-flow.md`
+3. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+4. **ADR**: `docs/adr/006-hash-uniqueness.md`, `docs/adr/007-adapter-pattern.md`
+5. **依存資産**: `pyproject.toml` `[project.dependencies]` に宣言済みの `click>=8.1,<9` を採用
+6. **DB 接続**: `src/kakeibo/db/session.py`（Phase 0 で作成済み engine factory）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/ingest/__init__.py` | 既存（公開 API 集約に追記） |
+| `src/kakeibo/ingest/cli.py` | CLI エントリ + `main()` |
+| `src/kakeibo/ingest/__main__.py` | `python -m kakeibo.ingest` 起動用（`from .cli import main; main()`） |
+| `src/kakeibo/ingest/registry.py` | 機関 → アダプタクラスのレジストリ |
+| `src/kakeibo/ingest/persister.py` | DB 永続化（`INSERT ... ON CONFLICT (hash) DO NOTHING`） |
+| `tests/unit/ingest/__init__.py` | 新規 |
+| `tests/unit/ingest/test_cli.py` | CLI 引数・終了コード・dry-run のテスト（`CliRunner`） |
+| `tests/unit/ingest/test_persister.py` | 冪等 INSERT 検証（実 Postgres or testcontainers） |
+| `tests/unit/ingest/test_registry.py` | レジストリ参照と未対応機関 |
+
+`pyproject.toml` の `[project.scripts]` に既に `kakeibo = "kakeibo.__main__:main"` が宣言されている。本タスクで `kakeibo.ingest` サブコマンドへの委譲を `src/kakeibo/__main__.py` に実装するか、`python -m kakeibo.ingest` 直接呼びを採用するかの方針を決める（**`python -m kakeibo.ingest` 直接呼び** を推奨。`kakeibo` トップ CLI は Phase 4 で導入）。
+
+## 実装方針（原典 §実装方針より要約）
+
+1. **CLI フレームワーク**: `click` を採用（`CliRunner` で in-process テスト可能）。
+2. **コマンドシグネチャ**: `python -m kakeibo.ingest <institution> <path> [--dry-run] [--account-id INT]`。
+3. **アダプタ呼び出し**: `registry.get(institution)` でクラス取得 → `adapter = cls(account_id=...)` → `adapter.parse(file_bytes)`。
+4. **DB 永続化**: SQLAlchemy Core の `insert(transactions).on_conflict_do_nothing(index_elements=["hash"])`（`postgresql.insert`）。トランザクション境界はコマンド全体で 1 つ。
+5. **dry-run**: `--dry-run` 指定時は永続化スキップ、件数 + 先頭 3 件を `print`。
+6. **終了コード規約**: 成功 = 0、引数不正 = 2、パース失敗 = 3（`EncodingMismatchError` / `ColumnMissingError` / `ValueError`）、DB エラー = 4（`psycopg.Error`）。
+7. **ログ**: `logging.getLogger("kakeibo.ingest")`。INFO で件数、WARNING で重複スキップ件数。
+8. **テスト DB**: dev 依存の `testcontainers.postgres.PostgresContainer` を session-scope fixture で利用、`postgres/01` の Alembic マイグレーションを適用してから各テストを流す。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/ingest/test_cli.py` で `CliRunner().invoke(...)` ベースのテストを書く：
+  - 正常系（mufg / smbc それぞれで exit 0、行数増加）
+  - 冪等性（同一ファイル 2 回で 2 回目の行数変化なし）
+  - dry-run（行数 0 のまま、stdout に件数表示）
+  - 壊れた CSV → exit 3、未対応機関 → exit 2
+- `tests/unit/ingest/test_persister.py` で `persister.persist(...)` を直接呼び、`ON CONFLICT DO NOTHING` の挙動確認。
+- `tests/unit/ingest/test_registry.py` で `registry.get("mufg")` / `registry.get("nonexistent")` の挙動。
+
+### 2. Green
+
+- `registry.py` を最小実装（`{"mufg": MufgCsvAdapter, "smbc": SmbcCsvAdapter}`）。
+- `persister.py` で SQLAlchemy Core の bulk `INSERT ... ON CONFLICT DO NOTHING`。
+- `cli.py` で click コマンドを定義し、上記を呼び出す。
+- 各テストを順に通す。エラーパスは最後にまとめて。
+
+### 3. Refactor
+
+- 永続化ロジックを CLI から完全分離（`persister.persist(transactions)` で受け取る）。
+- 例外 → 終了コードマッピングを `_handle_exception(exc) -> int` に集約。
+
+## 受入条件
+
+- CLI で MUFG / SMBC の CSV を取り込み、`transactions` 行数が増える
+- 同じファイル 2 回投入で 2 回目に行数増加なし（`ON CONFLICT DO NOTHING`）
+- 終了コード: 成功 0 / 引数不正 2 / パース失敗 3 / DB エラー 4
+- `--dry-run` で DB 書込みなし、stdout に件数 + 先頭 3 件
+- 未対応機関で exit 2 + 適切なエラーメッセージ
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/ingest/      # 全件緑（< 30 秒、testcontainers 起動含む）
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/ingest-cli`
+- コミット粒度（最低 6 件）：
+  1. `テスト: 取込CLIの正常系・冪等性・dry-run・エラーパスのテストを先行作成`
+  2. `機能: 機関→アダプタクラスのレジストリを追加`
+  3. `機能: ON CONFLICT DO NOTHINGによる冪等永続化レイヤを実装`
+  4. `機能: clickベースの取込CLIエントリを実装`
+  5. `機能: 例外→終了コードマッピングを追加`
+  6. `機能: --dry-runオプションと件数サマリ出力を追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.6 取込CLI を実装。
+
+## 成果物
+- src/kakeibo/ingest/{cli,registry,persister,__main__}.py
+- tests/unit/ingest/{test_cli,test_registry,test_persister}.py
+
+## 検証結果
+- pytest tests/unit/ingest/: 全件緑
+- 同一CSV 2回投入で行数変化なし（冪等性）
+- 終了コード規約（0/2/3/4）動作確認
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+（あれば）
+
+## 次のアクション提案
+worker/06 (ハッシュ冪等性PBT) と worker/07 (月次サマリ) を並行着手可能。
+```
+
+## 注意事項
+
+- `click` は `[project.dependencies]` に既に宣言済み（`click>=8.1,<9`）。新規依存追加は不要。
+- **dry-run 時に DB に書き込まない** ことをテストで明示（行数 0 を確認）。
+- DB エラー時のロールバック挙動は SQLAlchemy のトランザクション境界で担保（`with engine.begin()`）。
+- 機関コード判定は CLI 引数で行い、ディレクトリ名からの自動判定は **Phase 2.1 Watcher の責務**（責務分離）。
+- `pytest-postgresql` は dev 依存に未宣言。`testcontainers` を使用。
+- `pyproject.toml` の `[project.scripts]` `kakeibo = "kakeibo.__main__:main"` は別タスクで実体化（Phase 4 想定）。Phase 1 では `python -m kakeibo.ingest` 直接呼びを正規ルートとする。

--- a/docs/plans/worker/06-hash-idempotency-tests.md
+++ b/docs/plans/worker/06-hash-idempotency-tests.md
@@ -1,0 +1,142 @@
+---
+title: worker/06 ハッシュ冪等性ユニットテスト強化
+service: worker
+phase_task_id: 1.7
+priority: 中
+source_plan: docs/plans/08-phase1-hash-idempotency-tests.md
+branch: feature/hash-idempotency-tests
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/06 ハッシュ冪等性ユニットテスト強化（Phase 1.7）
+
+## このファイルの位置付け
+
+原典 `docs/plans/08-phase1-hash-idempotency-tests.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。Phase1 完了条件 (b) の保険として機能する。
+
+## 担当サービス
+
+`worker` コンテナ。`compute_hash`（`worker/01` で実装済）の境界条件を property-based test で網羅し、description の前後空白の扱いを **テストで固定** する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/01`（共通型）, `worker/05`（取込CLI） |
+| 下流 | `worker/07`（月次サマリ）以降の集計タスク |
+
+`worker/07` と並行可能。
+
+## 入力
+
+1. **原典**: `docs/plans/08-phase1-hash-idempotency-tests.md`（必読）
+2. **ADR**: `docs/adr/006-hash-uniqueness.md`
+3. **データモデル**: `postgres/docs/design/01-data-model.md`
+4. **既存実装**: `src/kakeibo/domain/transaction.py` の `compute_hash`
+5. **依存**: `pyproject.toml` `[project.optional-dependencies].dev` に `hypothesis>=6.100,<7` 宣言済み（追加不要）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `tests/unit/domain/test_hash.py` | hypothesis ベースの property-based test |
+| `tests/unit/domain/test_hash_boundary.py` | 境界条件の表駆動テスト |
+| `src/kakeibo/domain/transaction.py` | （**変更しない**を初期方針。ただし境界条件で正規化方針を変える場合は ADR-006 改訂と同時に） |
+
+## 実装方針（原典 §実装方針より要約）
+
+### hypothesis 戦略
+
+| 引数 | 戦略 |
+|---|---|
+| `account_id` | `st.integers(min_value=1, max_value=10**6)` |
+| `occurred_on` | `st.dates(min_value=date(2000,1,1), max_value=date(2100,12,31))` |
+| `amount` | `st.decimals(min_value=Decimal("-1e9"), max_value=Decimal("1e9"), places=4, allow_nan=False, allow_infinity=False)` |
+| `description` | `st.text(min_size=0, max_size=200)` |
+
+### 検証ポイント
+
+1. **決定性**: `@given(...)` で生成した入力に対し、`compute_hash(...) == compute_hash(...)` を毎回確認。
+2. **1 引数違いで別ハッシュ**: 4 引数のうち 1 つだけ変えたペアが必ず別ハッシュ（`account_id +1` など）。
+3. **大量サンプル衝突ゼロ**: 100 件のランダム入力でハッシュ集合のサイズが 100。
+4. **境界条件（表駆動）**:
+   - description の前後半角空白差異 → 別ハッシュ（**正規化しない方針** が初期採用、ADR-006 と整合）
+   - 全角空白と半角空白 → 別ハッシュ
+   - 改行コード（`\r\n` vs `\n`） → 別ハッシュ
+   - Unicode NFC / NFD → 別ハッシュ（`unicodedata.normalize` を `compute_hash` に組み込まない方針）
+   - 空文字 description の扱い（許容するが衝突しないことを確認）
+5. **通貨の扱い**: 現行 `compute_hash` シグネチャに `currency` がないため、「同 description / 異 currency 取引が同ハッシュとなる」ことを **明示的にテスト** し、コメントで「機関ごとに通貨は固定なので account_id で区別される」を残す（ADR-006 改訂は別タスク）。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/domain/test_hash.py` を作成し、上記 hypothesis テストを記述。
+- `tests/unit/domain/test_hash_boundary.py` で表駆動テスト（空白・改行・Unicode 正規化）。
+- `pytest tests/unit/domain/test_hash*.py` で `compute_hash` の現挙動を検証。多くは緑になるはずだが、想定外の衝突があれば赤になる。
+
+### 2. Green
+
+- 原則 `compute_hash` 本体は **変更しない**（Phase 1.2 の確定挙動を尊重）。
+- 期待値が異なるテストがあれば、まず原典 `docs/plans/03-phase1-domain-types.md` §実装方針 4 と整合を確認し、テスト側を修正（仕様優先）。
+- どうしても本体修正が必要な境界条件が見つかった場合は **ADR-006 改訂タスクを別途起票** し、本タスクで勝手に変更しない。
+
+### 3. Refactor
+
+- テストデータ生成ヘルパ（`_make_args(...)`）を抽出。
+- 境界条件テーブルをモジュール定数化。
+
+## 受入条件
+
+- 同一 `(account_id, occurred_on, amount, description)` で同一ハッシュ（hypothesis 100 例以上）
+- description の前後空白差異で異なるハッシュ
+- 100 件ランダムサンプルで衝突 0
+- 1 引数違い 100 例で全件別ハッシュ
+- 通貨違いの取引が同ハッシュとなる現状をテストで明示（コメント付き）
+- `pyright` クリーン、`ruff` 違反ゼロ
+- テスト全件 10 秒以内
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/domain/test_hash.py tests/unit/domain/test_hash_boundary.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/hash-idempotency-tests`
+- コミット粒度（最低 3 件）：
+  1. `テスト: hypothesisベースのcompute_hash決定性・1引数違い・衝突ゼロのproperty-based testを追加`
+  2. `テスト: 空白・改行・Unicode正規化の境界条件を表駆動で固定`
+  3. `テスト: currency引数非対応の現状を明示するテストとコメントを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.7 ハッシュ冪等性 property-based test を強化。
+
+## 成果物
+- tests/unit/domain/{test_hash.py, test_hash_boundary.py}
+
+## 検証結果
+- pytest tests/unit/domain/test_hash*.py: 全件緑（X 秒）
+- 100件サンプル衝突: 0件
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+- compute_hash の currency 非対応は明示的なテストで固定。改訂が必要なら ADR-006 改訂を別タスクで起票。
+
+## 次のアクション提案
+worker/07（月次サマリSQL）と統合確認。
+```
+
+## 注意事項
+
+- `compute_hash` 本体を **本タスクでは変更しない** が原則。仕様変更が必要なら ADR-006 改訂タスクを起票。
+- hypothesis のシード固定（`@settings(deadline=None, max_examples=100)`）でテスト実行時間を 10 秒以内に保つ。
+- description の正規化方針（NFC / NFKC / strip）を将来導入する場合、`worker/03` `worker/04` の摘要正規化と整合させる必要がある。本タスクでは「正規化しない」を初期方針。

--- a/docs/plans/worker/07-monthly-summary-sql.md
+++ b/docs/plans/worker/07-monthly-summary-sql.md
@@ -1,0 +1,160 @@
+---
+title: worker/07 月次サマリ SQL
+service: worker
+phase_task_id: 1.8
+priority: 中
+source_plan: docs/plans/09-phase1-monthly-summary-sql.md
+branch: feature/monthly-summary-sql
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/07 月次サマリ SQL（Phase 1.8）
+
+## このファイルの位置付け
+
+原典 `docs/plans/09-phase1-monthly-summary-sql.md` を `worker` サービス担当の指示書として再編。原典との乖離時は原典優先。Phase1 完了条件 (c)「SQL で月次サマリが手計算と一致」を直接満たす。
+
+## 担当サービス
+
+`worker` コンテナ。`sql/queries/monthly_summary.sql`（クエリ本体）と `src/kakeibo/sql/runner.py`（アプリ層からの呼び出しヘルパ）。クエリ本体は `postgres` サービスのスキーマを前提とするが、ファイル・テストは `worker` 帰属。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/05`（取込CLI: 集計対象データを生成する手段） |
+| 下流 | Phase 3.3 月次推移グラフ、Phase 4.5 Obsidian 月次出力（本プラン群対象外） |
+
+`worker/06` と並行可能。
+
+## 入力
+
+1. **原典**: `docs/plans/09-phase1-monthly-summary-sql.md`（必読）
+2. **データモデル**: `postgres/docs/design/01-data-model.md`
+3. **ADR**: `docs/adr/004-postgres-jsonb.md`
+4. **既存スキーマ**: `postgres/01` 完了後の `transactions` / `categories` テーブル
+5. **既存資産**: `sql/queries/.gitkeep`（プレースホルダ）、`pyproject.toml` の `psycopg`, `sqlalchemy` 依存
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `sql/queries/monthly_summary.sql` | 月次サマリ SQL 本体 |
+| `src/kakeibo/sql/__init__.py` | パッケージ初期化（公開 API: `run_query`） |
+| `src/kakeibo/sql/runner.py` | `run_query(filename, **params)` 実装 |
+| `tests/fixtures/sql/monthly_summary_seed.sql` | テスト用フィクスチャ（institutions / accounts / categories / transactions の少量サンプル） |
+| `tests/fixtures/sql/monthly_summary_expected.json` | 期待集計結果（手計算） |
+| `tests/unit/sql/__init__.py` | 新規 |
+| `tests/unit/sql/test_monthly_summary.py` | クエリ実行 + 期待結果比較 |
+
+## 実装方針（原典 §実装方針より要約）
+
+### SQL 構造
+
+```sql
+SELECT
+    date_trunc('month', occurred_on)::date AS month,
+    COALESCE(c.name, 'その他') AS category_name,
+    SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END) AS expense,
+    SUM(CASE WHEN t.amount > 0 THEN t.amount ELSE 0 END) AS income,
+    COUNT(*) AS tx_count
+FROM transactions t
+LEFT JOIN categories c ON c.id = t.category_id
+WHERE occurred_on >= :date_from AND occurred_on < :date_to
+GROUP BY 1, 2
+ORDER BY 1, 2;
+```
+
+### 設計上のポイント
+
+1. **パラメータ**: `:date_from`（含む）, `:date_to`（含まない）の半開区間。
+2. **未分類取引**: `LEFT JOIN` + `COALESCE(c.name, 'その他')` で取りこぼし防止。
+3. **金額符号**: 出金は負値で格納されているので `-t.amount` で正の支出額。
+4. **runner ヘルパ**: `pathlib.Path(__file__).parent.parent.parent / "sql" / "queries" / filename` で SQL を読み込む。`SQLAlchemy text()` で `:name` バインディングを使う（`psycopg` 経由でも `sqlalchemy.text` 経由でも整合）。
+5. **テストフィクスチャ**: `monthly_summary_seed.sql` で 5〜10 件投入。期待値は `expected.json` に手計算で記載。`json.loads(parse_float=Decimal)` で読み込む。
+6. **比較**: `Decimal` 精度で完全一致比較。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/sql/monthly_summary_seed.sql` で institutions / accounts / categories / transactions を 2 か月分・5〜10 件投入。
+- `tests/fixtures/sql/monthly_summary_expected.json` に期待集計結果を手計算で記述（`Decimal` 精度）。
+- `tests/unit/sql/test_monthly_summary.py` で次を網羅：
+  - 基本集計（全件一致）
+  - 未分類取引が `その他` に集計
+  - 期間境界（月末 vs 翌月 1 日）
+  - 空期間で空リスト
+  - 複数月で月ごとに正しく分割
+- `runner.run_query(...)` 未実装で全件落ちることを確認。
+
+### 2. Green
+
+- `src/kakeibo/sql/runner.py` で `run_query(filename: str, *, engine: Engine, **params)` を最小実装。
+- `sql/queries/monthly_summary.sql` を上記構造で実装。
+- 各テストを順に通す。
+
+### 3. Refactor
+
+- SQL を CTE で読みやすくする。
+- runner にファイル読込のキャッシュ機構を入れる（必要時のみ）。
+
+## 受入条件
+
+- サンプルデータ投入後、SQL 出力が `expected.json` と Decimal 精度で完全一致
+- カテゴリ未分類取引（`category_id IS NULL`）が `その他` に集計
+- pytest からクエリを呼び出して値検証可能
+- 期間境界 `[from, to)` の半開区間で正しく動作
+- 複数月データで月ごとに分割
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/sql/         # 全件緑（testcontainers 起動含む）
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/monthly-summary-sql`
+- コミット粒度（最低 4 件）：
+  1. `テスト: 月次サマリの基本集計・未分類・期間境界テストを先行作成`
+  2. `機能: SQLファイル読込ヘルパとrun_queryランナーを実装`
+  3. `機能: 月次サマリSQLクエリ本体を実装`
+  4. `テスト: フィクスチャ（投入データ + 期待結果JSON）を追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 1.8 月次サマリ SQL を実装。
+
+## 成果物
+- sql/queries/monthly_summary.sql
+- src/kakeibo/sql/{__init__.py, runner.py}
+- tests/fixtures/sql/{monthly_summary_seed.sql, monthly_summary_expected.json}
+- tests/unit/sql/test_monthly_summary.py
+
+## 検証結果
+- pytest tests/unit/sql/: 全件緑
+- 月次サマリが手計算と完全一致（Decimal精度）
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+（あれば）
+
+## 次のアクション提案
+Phase1 完了条件 (a) (b) (c) (d) すべて達成。Phase 2 着手準備が整った。
+```
+
+## 注意事項
+
+- 期間は **半開区間 `[from, to)`** を採用（`>= :date_from AND < :date_to`）。月末 23:59:59 / 翌月 0:00 のグレーゾーンを排除。
+- `expected.json` の `Decimal` は `json.loads(parse_float=Decimal)` で読み込み、`float` 経由で精度を失わせない。
+- フィクスチャの投入データに **実取引情報を含めない**（合成データのみ）。
+- インデックス最適化は本タスクでは不要（実データ規模で問題が顕在化してから対応、原典 §スコープ「含まない」）。
+- 本クエリは Phase 3.3 / Phase 4.5 で再利用される前提。`sql/queries/` 配下に独立配置することで再利用性を担保（ハードコードしない）。

--- a/docs/plans/worker/Ph2/01-watcher-service.md
+++ b/docs/plans/worker/Ph2/01-watcher-service.md
@@ -1,0 +1,146 @@
+---
+title: worker/Ph2/01 watchdog Watcher サービス
+service: worker
+phase_task_id: 2.1
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.1（行 211-221）
+branch: feature/watcher-service
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/01 watchdog Watcher サービス（Phase 2.1）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.2 Phase 2.1 を `worker` サービス担当の実装指示書として展開。Phase2 完了条件 (a)「CSV 投下 5 分以内に DB 反映」を直接満たす。原典との乖離時は原典優先。
+
+## 担当サービス
+
+`worker` コンテナ。Phase 0 で実装した heartbeat ループ（`src/kakeibo/worker/main.py`）を **取込スケジューラのディスパッチャに発展させる**（`src/kakeibo/worker/__init__.py` のコメント参照）。`/inbox/<institution>/` 配下の新規ファイルを監視し、Phase 1.6 で実装した取込CLIを subprocess（or in-process 関数）で起動する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph1/05`（取込CLI、Phase 1.6） |
+| 下流 | `worker/Ph2/02`（archive/dead_letter）, `worker/Ph2/08`（cron） |
+
+`worker/Ph2/03` (Gmail MCP) と独立並列可能。
+
+## 入力
+
+1. **原典**: `docs/plans/01-development-plan.md` §4.2 Phase 2.1
+2. **取込フロー**: `worker/docs/design/08-ingest-flow.md`
+3. **デプロイ**: `docs/design/04-deployment-stack.md`
+4. **ADR**: `docs/adr/007-adapter-pattern.md`, `docs/adr/009-nas-docker-compose.md`
+5. **既存資産**:
+   - `src/kakeibo/worker/main.py`（Phase 0 heartbeat ループ。本タスクで内容拡張）
+   - `src/kakeibo/ingest/cli.py`（Phase 1.6 で実装される取込CLI）
+   - `src/kakeibo/ingest/registry.py`（機関 → アダプタ）
+   - `compose.yml` `worker` の volume `./inbox:/inbox:rw`
+6. **依存パッケージ**: `pyproject.toml` に **`watchdog` を追加** が必要（dev ではなく runtime 依存。`[project.dependencies]` に `"watchdog>=4,<5"` を追記）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `pyproject.toml` | `watchdog>=4,<5` を `[project.dependencies]` に追加 |
+| `src/kakeibo/ingest/watcher.py` | watchdog `Observer` ベースの Watcher 本体 |
+| `src/kakeibo/ingest/dispatch.py` | ディレクトリ名 → 機関コード判定 + 取込CLI 起動 |
+| `src/kakeibo/worker/main.py` | heartbeat ループに Watcher 起動を統合（既存の API は維持） |
+| `tests/unit/ingest/test_watcher.py` | watchdog をモックしてイベント発火検証 |
+| `tests/unit/ingest/test_dispatch.py` | 機関コード判定とリトライ |
+| `tests/integration/watcher/test_watcher_e2e.py` | `tmp_path` で実ファイル投下 → DB 反映の統合テスト |
+
+## 実装方針
+
+1. **watchdog 採用**: `watchdog.observers.Observer` + `FileSystemEventHandler`。デバウンス（同一ファイルの複数イベント抑制）は 1 秒の windowed dispatch で実装。
+2. **機関コード自動判定**: `/inbox/<institution>/<filename>` のディレクトリ階層から `institution` を取り出す。`registry.get(institution)` が `KeyError` なら **dead_letter へ即移動**（`worker/Ph2/02` と連携）。
+3. **取込起動方式**: 当面は **in-process 関数呼び出し**（`from kakeibo.ingest.cli import ingest_file; ingest_file(institution, path)`）を採用。subprocess は cron バッチ（`worker/Ph2/08`）と Phase 2.1 のリトライで利用検討。
+4. **ファイルロック競合リトライ**: パース対象ファイルが書き込み中の可能性に対し、サイズ安定確認（`os.stat(path).st_size` を 500ms 間隔で 2 回チェックして同値）→ 失敗時は最大 3 回リトライ。
+5. **graceful shutdown**: Phase 0 の `stop_event: threading.Event` パターンを継承し、SIGTERM / SIGINT で `Observer.stop()` + `join(timeout=5)`。
+6. **heartbeat 維持**: 既存の heartbeat 更新は維持（HEALTHCHECK 互換性）。Watcher 起動後も周期的に touch する。
+7. **ログ**: `structlog` で `event=watcher_started`, `event=file_detected`, `event=ingest_completed`, `event=ingest_failed`。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/ingest/test_watcher.py` で `watchdog.events.FileSystemEvent` を直接ハンドラに渡し、ディスパッチが期待通り呼ばれることを `unittest.mock.MagicMock` で検証。
+- `tests/unit/ingest/test_dispatch.py` で機関コード判定 / 未対応機関で dead_letter 行き / リトライ挙動を検証。
+- `tests/integration/watcher/test_watcher_e2e.py` で `tmp_path` 配下に `mufg/sample.csv` を配置 → 5 秒以内に testcontainers Postgres へ取引が INSERT されることを確認（前提: `worker/Ph1/05` 完了で取込CLI が動く）。
+- 全件赤になることを確認。
+
+### 2. Green
+
+- `pyproject.toml` に `watchdog` を追加し `uv sync`。
+- `src/kakeibo/ingest/dispatch.py` を最小実装（機関コード判定 + `ingest_file` 呼び出し）。
+- `src/kakeibo/ingest/watcher.py` で `Observer` を初期化し、`FileSystemEventHandler` のサブクラスを登録。
+- `src/kakeibo/worker/main.py` の `run()` を改修し、`heartbeat_path` ループと並行して Watcher を起動。
+
+### 3. Refactor
+
+- ファイルサイズ安定確認を `_wait_file_stable(path, attempts=3, interval=0.5)` に抽出。
+- リトライポリシーを `_retry_with_backoff(...)` に抽出（PayPal の指数バックオフと共通化可能性は Phase 2.7 で評価）。
+
+## 受入条件
+
+- サービス起動状態で `/inbox/mufg/sample.csv` 投下から **5 分以内**（実測は 5 秒以内）に DB に反映
+- 機関コードがディレクトリ名（`/inbox/<institution>/...`）から自動判定される
+- ファイルロック競合時のリトライが実装されている（最大 3 回）
+- SIGTERM / SIGINT で graceful shutdown（`Observer.stop()` + `join(timeout=5)`）
+- HEALTHCHECK の heartbeat ファイルが Watcher 起動中も更新される
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/ingest/test_watcher.py tests/unit/ingest/test_dispatch.py
+pytest tests/integration/watcher/      # testcontainers 起動含む
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/watcher-service`
+- コミット粒度（最低 5 件）：
+  1. `テスト: watchdogイベントハンドラとディスパッチ・統合E2Eのテストを先行作成`
+  2. `設定: watchdog依存パッケージをpyproject.tomlに追加`
+  3. `機能: 機関コード判定とリトライ付き取込ディスパッチを実装`
+  4. `機能: watchdog Observerベースのファイル監視Watcherを実装`
+  5. `機能: workerメインループにWatcher起動とgraceful shutdownを統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.1 watchdog Watcher サービスを実装。
+
+## 成果物
+- pyproject.toml（watchdog 追加）
+- src/kakeibo/ingest/{watcher,dispatch}.py
+- src/kakeibo/worker/main.py（拡張）
+- tests/unit/ingest/test_watcher.py / test_dispatch.py
+- tests/integration/watcher/test_watcher_e2e.py
+
+## 検証結果
+- pytest（unit + integration）: 全件緑
+- /inbox 投下 → DB 反映: 平均 X 秒
+- SIGTERM graceful shutdown 動作確認
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/02 (Archive/DLQ) 着手可能。
+```
+
+## 注意事項
+
+- watchdog は **runtime 依存**として追加（`[project.dependencies]`）。dev のみだと本番イメージで `ImportError`。
+- ファイル投下中の競合（書き込み途中）対策で **サイズ安定確認**を入れること（巨大 CSV をスキャンし始めて壊れるパターン防止）。
+- 統合テストでは testcontainers を使う（`pytest-postgresql` は dev 依存に未宣言）。
+- 機関コード判定の **大文字小文字** は原典で未確定。`institution.lower()` で正規化する暫定ポリシー（CLI 側のレジストリも小文字キーを採用）。
+- `RawMail` のような新規ドメイン型は本タスクでは追加しない（メール系は `worker/Ph2/03` で扱う）。

--- a/docs/plans/worker/Ph2/02-archive-and-dead-letter.md
+++ b/docs/plans/worker/Ph2/02-archive-and-dead-letter.md
@@ -1,0 +1,130 @@
+---
+title: worker/Ph2/02 アーカイブ移動 + dead letter
+service: worker
+phase_task_id: 2.2
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.2（行 223-233）
+branch: feature/archive-and-dead-letter
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/02 アーカイブ移動 + dead letter（Phase 2.2）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.2 Phase 2.2 を `worker` サービス担当の指示書として展開。Phase2 完了条件 (d)「失敗ファイルが dead_letter へ移動」を直接満たす。
+
+## 担当サービス
+
+`worker` コンテナ。取込成功/失敗の **後処理**（archive 移動・dead letter 隔離・エラーログ書き出し）を `worker/Ph2/01` Watcher の中から呼び出す。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph2/01`（Watcher） |
+| 下流 | `worker/Ph2/08`（cron バッチでも archive ロジックを再利用） |
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.2（行 223-233）
+2. **取込フロー**: `worker/docs/design/08-ingest-flow.md`
+3. **ADR**: `docs/adr/009-nas-docker-compose.md`, `docs/adr/012-three-tier-backup.md`
+4. **既存資産**:
+   - `compose.yml` `worker` の volume `./archive:/archive:rw`, `./dead_letter:/dead_letter:rw`
+   - `src/kakeibo/config.py` の `archive_path`, `dead_letter_path`（環境変数 `ARCHIVE_PATH`, `DEAD_LETTER_PATH` から）
+5. **依存**: 標準ライブラリ `shutil`, `datetime`, `pathlib`（追加依存なし）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/ingest/archiver.py` | `archive_success(path)`, `archive_failure(path, error)` の純関数 |
+| `src/kakeibo/ingest/watcher.py` | （既存）archiver 呼び出しを統合 |
+| `tests/unit/ingest/test_archiver.py` | 成功 / 失敗 / 衝突 / エラーログ併置テスト |
+| `tests/integration/archiver/test_archiver_e2e.py` | tmp_path で実ファイル移動を検証 |
+
+## 実装方針
+
+1. **成功時の移動先**: `archive_path / institution / occurred_year_month / filename`。`occurred_year_month` は `YYYY-MM`（取込日ではなく **取込実行時刻**を採用、原典と整合）。
+2. **失敗時の移動先**: `dead_letter_path / filename` 直下。`<filename>.error.log` を併置（例外クラス名 / メッセージ / トレースバック）。
+3. **同名ファイル衝突**: `<stem>_<YYYYMMDDhhmmss>.<suffix>` でリネーム。タイムスタンプは UTC ベース。
+4. **inbox からの除去**: `shutil.move(src, dst)` で原子的に。途中失敗時はリトライではなく例外を伝播（Watcher 側で再試行）。
+5. **エラーログのフォーマット**: 1 行目に例外クラス名 + メッセージ、空行、`traceback.format_exc()` 全文。トークン・シークレットを含むメッセージは絶対に書き込まない（`agent-rules/12-security-guidelines.md`）。
+6. **権限**: `worker` コンテナの非 root ユーザ（`kakeibo`、UID 1000）が読み書きできる必要がある。volume の所有権は事前に揃えておく前提。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/ingest/test_archiver.py`：
+  - 成功時に `archive_path / mufg / 2026-05 / sample.csv` に移動、inbox から消滅
+  - 失敗時に `dead_letter_path / sample.csv` + `sample.csv.error.log`
+  - 同名衝突時にタイムスタンプ付きリネーム
+  - `error.log` にトークン文字列が含まれていないこと（pytest fixture でログを inspect）
+- `tests/integration/archiver/test_archiver_e2e.py` で実ファイル移動。
+
+### 2. Green
+
+- `src/kakeibo/ingest/archiver.py` に `archive_success(path: Path, *, institution: str, archive_root: Path) -> Path` と `archive_failure(path: Path, *, error: Exception, dead_letter_root: Path) -> Path` を実装。
+- `watcher.py` から取込結果に応じて呼び分ける。
+
+### 3. Refactor
+
+- 衝突回避のリネームロジックを `_resolve_collision(target: Path) -> Path` に抽出。
+- `_format_error_log(error: Exception) -> str` を独立関数にしてテストしやすくする。
+
+## 受入条件
+
+- 成功時にファイルが `archive_path/<institution>/<YYYY-MM>/` へ移動し inbox から消える
+- パース例外時に dead_letter へ移動し `<file>.error.log` が併置される
+- 同名ファイル衝突時にタイムスタンプが付与される
+- error.log に **トークン・シークレット文字列が含まれない** ことをテストで保証
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/ingest/test_archiver.py tests/integration/archiver/
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/archive-and-dead-letter`
+- コミット粒度（最低 4 件）：
+  1. `テスト: archive成功/失敗/衝突/エラーログ機微情報除外のテストを先行作成`
+  2. `機能: archive_success / archive_failure 純関数を実装`
+  3. `機能: error.log書き出しと衝突時タイムスタンプリネームを追加`
+  4. `機能: WatcherにArchiver呼び出しを統合`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.2 アーカイブ移動 + dead letter を実装。
+
+## 成果物
+- src/kakeibo/ingest/archiver.py
+- tests/unit/ingest/test_archiver.py
+- tests/integration/archiver/test_archiver_e2e.py
+
+## 検証結果
+- 全件緑（unit + integration）
+- error.log にトークン非混入を確認
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/03 (Gmail MCP) と並行 / worker/Ph2/08 (cron) で再利用可能。
+```
+
+## 注意事項
+
+- error.log への書き込み時、**例外メッセージにトークン値が含まれる可能性**がある（HTTP クライアントのエラーメッセージ等）。`agent-rules/12-security-guidelines.md` に従い、シークレット候補文字列をマスクするフィルタを通す（`re.sub(r'(token|secret|key)=\S+', r'\1=***', msg, flags=re.IGNORECASE)`）。
+- `shutil.move` は **異なるファイルシステム間で fall back コピー＋削除**になる。Docker volume が同一 FS にある前提で `os.rename` 同等の原子性を期待してよい。
+- `archive_path` / `dead_letter_path` が存在しない場合は **作成しない**（運用時に明示的に作成する volume なので）。`FileNotFoundError` を伝播させて運用ミスを早期検出。
+- 取込日・実行時刻は `datetime.now(timezone.utc)` で UTC 取得。タイムゾーン揺れを避ける（`compose.yml` の TZ=Asia/Tokyo はログ表示用、ファイル系処理は UTC）。

--- a/docs/plans/worker/Ph2/03-gmail-mcp-client.md
+++ b/docs/plans/worker/Ph2/03-gmail-mcp-client.md
@@ -1,0 +1,148 @@
+---
+title: worker/Ph2/03 Gmail MCP 接続
+service: worker
+phase_task_id: 2.3
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.3（行 235-245）
+branch: feature/gmail-mcp-client
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/03 Gmail MCP 接続（Phase 2.3）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.2 Phase 2.3 を `worker` サービス担当の指示書として展開。Phase2 の EC メールパーサ群（2.4 / 2.5 / 2.6）の **共通取得基盤**を作る。
+
+## 担当サービス
+
+`worker` コンテナ。Gmail API を **`gmail.readonly` スコープに限定** で叩き、対象ラベル/送信元のメール一覧と本文を取得して `RawMail` 共通型に正規化する。OAuth リフレッシュトークンは Docker secret 経由で読み込む（ADR-011 認証情報非保持）。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | なし（`worker/Ph2/01` Watcher と並行可） |
+| 下流 | `worker/Ph2/04`（Amazon）, `05`（楽天）, `06`（Yahoo） |
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.3（行 235-245）
+2. **セキュリティ**: `docs/design/05-security-model.md`
+3. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+4. **ADR**: `docs/adr/011-no-credentials-storage.md`
+5. **既存資産**:
+   - `compose.yml` `worker` の secret `gmail_oauth_token` と環境変数 `GMAIL_OAUTH_TOKEN_FILE=/run/secrets/gmail_oauth_token`
+   - `secrets/gmail_oauth_token.json.example`（フォーマット参考）
+   - `src/kakeibo/config.py` `gmail_oauth_token_path: Path | None`（既存）
+6. **依存追加が必要**: `pyproject.toml` に `google-auth>=2.30,<3` および `google-api-python-client>=2.130,<3` を `[project.optional-dependencies].mail` に追加（`mail-parser` 系と同じ extras に集約）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `pyproject.toml` | `mail` extras に `google-auth`, `google-api-python-client` 追加 |
+| `src/kakeibo/domain/raw_mail.py` | `RawMail` dataclass（`message_id: str`, `from_addr: str`, `subject: str`, `received_at: datetime`, `body_text: str`, `body_html: str | None`, `labels: tuple[str, ...]`） |
+| `src/kakeibo/domain/__init__.py` | `RawMail` 公開 API 追加 |
+| `src/kakeibo/adapters/gmail/__init__.py` | パッケージ初期化 |
+| `src/kakeibo/adapters/gmail/client.py` | OAuth トークン読込 + Gmail API 呼出 |
+| `src/kakeibo/adapters/gmail/auth.py` | リフレッシュトークン → アクセストークン変換、ログマスキング |
+| `tests/unit/adapters/gmail/test_client.py` | API レスポンスをモックして `RawMail` 正規化検証 |
+| `tests/unit/adapters/gmail/test_auth.py` | トークンマスキング検証（ログキャプチャ） |
+| `tests/fixtures/gmail/sample_message.json` | Gmail API `users.messages.get` レスポンスの fixture |
+
+## 実装方針
+
+1. **OAuth スコープ**: 読み取り専用 `https://www.googleapis.com/auth/gmail.readonly` のみ。`scopes` を **コードで定数化** し、ハードコード以外を許可しない。
+2. **トークン読込**: `Settings.gmail_oauth_token_path` から JSON を読み、`google.oauth2.credentials.Credentials.from_authorized_user_info(...)` でロード。失効時は `refresh()` を試行し、失敗時は `RuntimeError("Gmail OAuth token expired")` を送出（自動再認可は Phase 2 では行わない）。
+3. **取得対象**: `query` パラメータで `from:auto-confirm@amazon.co.jp newer_than:30d` のような検索式を渡す API。Amazon / 楽天 / Yahoo のクエリは各パーサ（2.4 / 2.5 / 2.6）が指定する。
+4. **`RawMail` 正規化**: メッセージID / 送信元 / 件名 / 受信日時 / 本文（plain + html） / ラベル を抽出。base64url デコードは `email.message_from_bytes` で実施。
+5. **ログマスキング**: `auth.py` 内で `repr(credentials)` のような呼び出しを避け、トークン値が `structlog` ログに乗らないよう **専用ログ helper** を経由（`log.info("gmail_token_loaded", path=str(token_path))` のように値ではなくパスのみ記録）。
+6. **MCP 接続の有無**: 原典タイトルは「Gmail MCP 接続」だが、本タスクは **Google API クライアントによる直接接続** で実装。MCP 経由のラッパは Phase 4 以降で検討（実機関 API のクライアントは可逆実装を優先）。タイトルとの差異はコメントに記載。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/gmail/sample_message.json` を Gmail API `users.messages.get` のサンプル形式で作成（合成。実メールデータは入れない）。
+- `tests/unit/adapters/gmail/test_client.py`：
+  - `client.list_messages(query="...")` がメッセージ ID リストを返す（HTTP モック）
+  - `client.get_message(msg_id)` が `RawMail` を返す
+  - スコープ違反のクライアントを inject すると `ValueError`
+- `tests/unit/adapters/gmail/test_auth.py`：
+  - リフレッシュトークン JSON 読込でトークン値が `caplog` に含まれない
+  - 期限切れトークンで `RuntimeError`
+- `tests/unit/domain/test_raw_mail.py` で `RawMail` バリデーション。
+
+### 2. Green
+
+- `src/kakeibo/domain/raw_mail.py` で dataclass + バリデーション。
+- `src/kakeibo/adapters/gmail/auth.py` で OAuth ロード（`google.oauth2.credentials.Credentials`）。
+- `src/kakeibo/adapters/gmail/client.py` で `googleapiclient.discovery.build("gmail", "v1", credentials=...)` をラップ。
+- 各テストを順に通す。
+
+### 3. Refactor
+
+- スコープ定数を `_SCOPES = ("https://www.googleapis.com/auth/gmail.readonly",)` でモジュールトップレベル化。
+- `RawMail` 生成ロジックを `_message_to_raw_mail(msg: dict) -> RawMail` に抽出。
+
+## 受入条件
+
+- OAuth スコープが `gmail.readonly` のみであることをコードレベル + テストで保証
+- リフレッシュトークンが Docker secret 経由（`Settings.gmail_oauth_token_path`）で読み込まれる
+- 平文ログにトークンが出力されない（`caplog` で検証）
+- 取得結果が `RawMail` に正規化される
+- スコープ違反検出時に `ValueError`
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/gmail/ tests/unit/domain/test_raw_mail.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/gmail-mcp-client`
+- コミット粒度（最低 5 件）：
+  1. `テスト: RawMail型 / Gmail OAuth / メッセージ取得 / トークンマスキングのテストを先行作成`
+  2. `設定: google-auth と google-api-python-client を mail extras に追加`
+  3. `機能: RawMail共通型を追加`
+  4. `機能: gmail.readonly限定のOAuthクライアントを実装（トークンマスキング含む）`
+  5. `機能: Gmail APIクライアントとメッセージ→RawMail正規化を実装`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.3 Gmail 読み取り専用クライアントを実装。
+
+## 成果物
+- src/kakeibo/domain/raw_mail.py
+- src/kakeibo/adapters/gmail/{client,auth}.py
+- tests/unit/{domain/test_raw_mail.py, adapters/gmail/}
+- tests/fixtures/gmail/sample_message.json
+- pyproject.toml（mail extras 拡張）
+
+## 検証結果
+- 全件緑
+- スコープが gmail.readonly に限定されることを確認
+- caplog でトークン非露出を確認
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/04 (Amazon) / 05 (楽天) / 06 (Yahoo) を 3 並列で着手可能。
+```
+
+## 注意事項
+
+- **スコープ拡張禁止**: 将来「メールを送信したい」「ラベル変更したい」というニーズが出ても、本タスクのスコープ（readonly 限定）は変更不可。必要なら ADR を新規発番すること（`docs/adr/011-no-credentials-storage.md` の精神に沿う）。
+- **トークン値のログ出力厳禁**: `repr(credentials)`, `vars(credentials)`, `__dict__` 経由でログに乗せないこと。マスキング helper を必ず通す。
+- **実メールデータを fixture に入れない**: 件名・本文は合成。実 EC 注文の番号・金額・氏名は絶対に含めない。
+- **MCP の意味**: 原典タイトルが「Gmail MCP」だが、Phase 2 では Anthropic の Model Context Protocol ではなく Google API 直接接続を採用する（より単純で監査しやすい）。MCP 化は Phase 4 以降で再評価。指示書本文の `client.py` 名はこの方針を反映。
+- リフレッシュトークン失効時のリトライは Phase 2 では未実装。`R-04`（リスク）として残置し、運用 90 日でレビューする。

--- a/docs/plans/worker/Ph2/04-parser-amazon-mail.md
+++ b/docs/plans/worker/Ph2/04-parser-amazon-mail.md
@@ -1,0 +1,150 @@
+---
+title: worker/Ph2/04 Amazon 注文確認メールパーサ
+service: worker
+phase_task_id: 2.4
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.4（行 247-257）
+branch: feature/parser-amazon-mail
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/04 Amazon 注文確認メールパーサ（Phase 2.4）
+
+## このファイルの位置付け
+
+原典 `docs/plans/01-development-plan.md` §4.2 Phase 2.4 を `worker` サービス担当の指示書として展開。Phase 2.5 / 2.6（楽天 / Yahoo）と独立並行可能。
+
+## 担当サービス
+
+`worker` コンテナ。Amazon の注文確認メール（HTML / Plain）を `Transaction` に正規化する `AmazonMailAdapter`。Gmail MCP（`worker/Ph2/03`）から取得した `RawMail` を入力とする。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph2/03`（Gmail MCP）, `worker/Ph1/02`（IngestAdapter ABC） |
+| 下流 | `worker/Ph2/08`（cron バッチ） |
+
+`worker/Ph2/05`, `worker/Ph2/06` と独立並列可能。
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.4（行 247-257）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **ADR**: `docs/adr/001-hybrid-ingestion-strategy.md`, `docs/adr/003-no-scraping.md`, `docs/adr/007-adapter-pattern.md`
+4. **既存資産**:
+   - `src/kakeibo/adapters/base.py`（IngestAdapter ABC）
+   - `src/kakeibo/domain/transaction.py`（`Transaction`, `compute_hash`）
+   - `src/kakeibo/domain/raw_mail.py`（`worker/Ph2/03` で実装される）
+5. **依存**: `mail-parser`, `beautifulsoup4`, `lxml`（`pyproject.toml` `[project.optional-dependencies].mail` に既宣言）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/mail/__init__.py` | 新規パッケージ |
+| `src/kakeibo/adapters/mail/amazon.py` | `AmazonMailAdapter` 実装 |
+| `tests/fixtures/mail/amazon/normal.eml` | 通常購入の合成メール |
+| `tests/fixtures/mail/amazon/multiple_items.eml` | 複数商品 |
+| `tests/fixtures/mail/amazon/gift_card.eml` | ギフト券利用 |
+| `tests/fixtures/mail/amazon/expected.json` | 期待 Transaction 配列 |
+| `tests/unit/adapters/mail/test_amazon.py` | ゴールデンマスタ + エッジケース |
+
+## 実装方針
+
+1. **クラス**: `AmazonMailAdapter(IngestAdapter)`、`source: ClassVar[str] = "amazon_mail"`。
+2. **`parse(payload: RawMail | bytes) -> Iterable[Transaction]`**:
+   - `payload` が `bytes` なら `email.message_from_bytes` でパース → `RawMail` に変換 → 統一処理
+   - `RawMail.body_html` 優先、なければ `body_text`
+   - HTML から `BeautifulSoup(html, "lxml")` で抽出
+3. **抽出フィールド**:
+   - 注文番号（`注文番号: <ID>` の正規表現）
+   - 注文日（メール件名 or 本文の日付。なければ `received_at.date()`）
+   - 合計金額（`合計: ¥<amount>` 正規表現、カンマ除去 → `Decimal`）
+   - 主商品名（先頭商品の名称、複数商品時は最初の 1 件 + `…他N件`）
+4. **金額符号**: 購入は **負値**（出費）。
+5. **`raw_payload`**: 注文番号・全商品名・元 HTML 抜粋を JSON で保持。
+6. **ハッシュ**: 共通 `compute_hash(self.account_id, occurred_on, amount, description)`。description に **注文番号を含める** ことで、同日同額の別注文を一意に区別する（原典「ハッシュは『注文番号 + 金額』で重複検出」と整合）。
+7. **ギフト券利用**: `ギフト券残高利用: -¥<amount>` のような表記を読み、合計金額に既に反映されているか確認 → 二重計上防止。
+8. **`extract_holdings`**: 空イテラブル `return ()`。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/mail/amazon/{normal,multiple_items,gift_card}.eml` を合成データで作成（実注文情報禁止）。
+- `tests/fixtures/mail/amazon/expected.json` に期待 Transaction を記述。
+- `tests/unit/adapters/mail/test_amazon.py`：
+  - 3 パターン全てでゴールデンマスタ完全一致
+  - 金額が `Decimal`、購入は負値
+  - 注文番号が `raw_payload["order_id"]` に保持される
+  - 同一メール 2 回パースでハッシュ一致
+  - 注文番号が異なれば同額同日でも別ハッシュ
+  - HTML が壊れている場合に `AdapterError`
+
+### 2. Green
+
+- `src/kakeibo/adapters/mail/amazon.py` で `AmazonMailAdapter` を最小実装。
+- `BeautifulSoup` での抽出 → 正規表現での金額抽出 → `Transaction` 生成。
+- 各テスト順に通す。
+
+### 3. Refactor
+
+- 共通正規表現（`_AMOUNT_RE`, `_ORDER_ID_RE`）をモジュールトップレベル化。
+- HTML / Plain の振り分けを `_extract_text(raw: RawMail) -> str` に抽出（楽天・Yahoo パーサと共通化検討は **しない**：早すぎる抽象化）。
+
+## 受入条件
+
+- 通常 / 複数商品 / ギフト券の 3 パターンで `expected.json` と完全一致
+- 金額が `Decimal` で生成される
+- 注文番号が `raw_payload["order_id"]` に保持される
+- ハッシュが「注文番号 + 金額」で重複検出可能（description に order_id 含む）
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/mail/test_amazon.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/parser-amazon-mail`
+- コミット粒度（最低 4 件）：
+  1. `テスト: Amazon メールゴールデンマスタ（通常/複数商品/ギフト券）テストを先行作成`
+  2. `機能: AmazonMailAdapter本体（HTMLから注文番号・金額・日付抽出）を実装`
+  3. `機能: ギフト券残高利用の検出と二重計上回避を追加`
+  4. `テスト: ハッシュ決定性と注文番号別の独立性を検証`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.4 Amazon 注文確認メールパーサを実装。
+
+## 成果物
+- src/kakeibo/adapters/mail/amazon.py
+- tests/fixtures/mail/amazon/{normal,multiple_items,gift_card}.eml
+- tests/fixtures/mail/amazon/expected.json
+- tests/unit/adapters/mail/test_amazon.py
+
+## 検証結果
+- 3 パターン全件緑
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/05, 06 と並行で進行可能。
+```
+
+## 注意事項
+
+- **スクレイピング不採用**（ADR-003）: メール本文以外（Amazon サイトの注文履歴 HTML）を取得しない。
+- **実注文情報を fixture に含めない**: 注文番号・氏名・住所・購入商品名は合成データのみ。テンプレートとして「`商品名サンプル_001`」のような placeholder を使う。
+- **楽天 / Yahoo との共通化を急がない**: 3 EC でメール構造が異なるため、Phase 2.4〜2.6 は独立実装で進める。共通基盤は Phase 4 以降で評価。
+- **HTML 構造変化リスク**: Amazon が HTML レイアウトを変える可能性がある。fixtures で固定化し、運用で破綻したらすぐ ADR を起票。
+- ハッシュ衝突の境界条件は `worker/Ph1/06`（PBT）と整合させる。description に order_id を含める方針はここで確定。

--- a/docs/plans/worker/Ph2/05-parser-rakuten-mail.md
+++ b/docs/plans/worker/Ph2/05-parser-rakuten-mail.md
@@ -1,0 +1,138 @@
+---
+title: worker/Ph2/05 楽天市場 注文確認メールパーサ
+service: worker
+phase_task_id: 2.5
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.5（行 259-269）
+branch: feature/parser-rakuten-mail
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/05 楽天市場 注文確認メールパーサ（Phase 2.5）
+
+## このファイルの位置付け
+
+原典 §4.2 Phase 2.5 を `worker` 担当の指示書として展開。Phase 2.4（Amazon）/ 2.6（Yahoo）と独立並列可能。
+
+## 担当サービス
+
+`worker` コンテナ。楽天市場の注文確認メールを `Transaction` に正規化する `RakutenMailAdapter`。Gmail MCP（`worker/Ph2/03`）から取得した `RawMail` を入力とする。**楽天ポイント利用額を別フィールドで保持する**点が特徴。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph2/03`（Gmail MCP）, `worker/Ph1/02`（IngestAdapter ABC） |
+| 下流 | `worker/Ph2/08`（cron） |
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.5（行 259-269）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **ADR**: `docs/adr/001-hybrid-ingestion-strategy.md`, `docs/adr/003-no-scraping.md`, `docs/adr/007-adapter-pattern.md`
+4. **既存資産**: `Transaction`, `compute_hash`, `RawMail`, `IngestAdapter` ABC
+5. **依存**: `mail-parser`, `beautifulsoup4`, `lxml`（既宣言）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/mail/rakuten.py` | `RakutenMailAdapter` 実装 |
+| `tests/fixtures/mail/rakuten/normal.eml` | ポイント利用なし合成メール |
+| `tests/fixtures/mail/rakuten/with_points.eml` | ポイント利用あり |
+| `tests/fixtures/mail/rakuten/expected.json` | 期待 Transaction 配列 |
+| `tests/unit/adapters/mail/test_rakuten.py` | ゴールデンマスタ + ポイント利用 + ハッシュ決定性 |
+
+## 実装方針
+
+1. **クラス**: `RakutenMailAdapter(IngestAdapter)`、`source: ClassVar[str] = "rakuten_mail"`。
+2. **`parse(payload: RawMail | bytes) -> Iterable[Transaction]`**:
+   - `body_html` 優先、なければ `body_text`
+   - `BeautifulSoup(html, "lxml")` で抽出
+3. **抽出フィールド**:
+   - 注文番号（`注文番号: <ID>` 正規表現）
+   - 注文日
+   - 商品合計（`商品合計: ¥<amount>`）
+   - **楽天ポイント利用**（`楽天ポイント: -<amount>` のような表記）
+   - 支払金額（`お支払金額: ¥<amount>` = 商品合計 − ポイント）
+4. **金額符号**: 支払金額（実際に決済された額）を `Transaction.amount` の **負値**として採用。
+5. **`raw_payload`**: 注文番号 / 商品合計 / ポイント利用額 / 支払金額を JSON で保持。**ポイント利用額は別フィールドで明示**（原典「楽天ポイント利用額が別フィールドで保持される」）。
+6. **ハッシュ**: 注文番号を description に含める（Phase 2.4 と同じ規約）。
+7. **`extract_holdings`**: 空イテラブル。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/mail/rakuten/{normal,with_points}.eml` を合成。
+- `tests/fixtures/mail/rakuten/expected.json` に期待値（ポイント利用額を含む）。
+- `tests/unit/adapters/mail/test_rakuten.py`：
+  - ポイント利用なし: `raw_payload["points_used"] == "0"` / `amount == -商品合計`
+  - ポイント利用あり: `raw_payload["points_used"] == "<利用額>"` / `amount == -支払金額`
+  - 注文番号別で別ハッシュ
+  - 同一メール 2 回パースでハッシュ一致
+
+### 2. Green
+
+- `src/kakeibo/adapters/mail/rakuten.py` で `RakutenMailAdapter` を最小実装。
+- 楽天独自の HTML 構造に合わせた正規表現を順に追加。
+
+### 3. Refactor
+
+- 共通定数（楽天ポイント表記のバリエーション）をモジュールトップレベル化。
+- Amazon との共通化は **しない**（メール構造差が大きい）。
+
+## 受入条件
+
+- 通常 / ポイント利用ありの 2 パターンで `expected.json` と完全一致
+- 楽天ポイント利用額が `raw_payload["points_used"]` で別フィールド保持
+- 注文番号で冪等性が成立（同注文 2 回投入で行数増えず）
+- 金額が `Decimal`、支払金額が負値で `amount` に格納
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/mail/test_rakuten.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/parser-rakuten-mail`
+- コミット粒度（最低 3 件）：
+  1. `テスト: 楽天メールゴールデンマスタ（通常/ポイント利用）テストを先行作成`
+  2. `機能: RakutenMailAdapter本体（注文番号・金額・ポイント抽出）を実装`
+  3. `機能: 楽天ポイント利用額のraw_payload保持と支払金額算出を追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.5 楽天市場 注文確認メールパーサを実装。
+
+## 成果物
+- src/kakeibo/adapters/mail/rakuten.py
+- tests/fixtures/mail/rakuten/{normal,with_points}.eml
+- tests/fixtures/mail/rakuten/expected.json
+- tests/unit/adapters/mail/test_rakuten.py
+
+## 検証結果
+- 全件緑（2 パターン）
+- ポイント利用額の別フィールド保持を確認
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/04, 06 完了を待って worker/Ph2/08 へ。
+```
+
+## 注意事項
+
+- **ポイント利用額を支払金額に二重計上しない**：商品合計 − ポイント = 支払金額の関係を fixture で固定し、テストで保証。
+- **スクレイピング禁止**（ADR-003）: メール本文以外（楽天サイトのマイページ）から取得しない。
+- **実注文情報を fixture に含めない**: 注文番号・氏名・住所・商品名は合成。
+- 楽天証券（投信・国内株・米国株）の CSV は **本タスクの対象外**（リスク R-02、Phase 1 拡張時に別 ADR）。

--- a/docs/plans/worker/Ph2/06-parser-yahoo-mail.md
+++ b/docs/plans/worker/Ph2/06-parser-yahoo-mail.md
@@ -1,0 +1,135 @@
+---
+title: worker/Ph2/06 Yahoo!ショッピング 注文確認メールパーサ
+service: worker
+phase_task_id: 2.6
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.6（行 271-281）
+branch: feature/parser-yahoo-mail
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/06 Yahoo!ショッピング 注文確認メールパーサ（Phase 2.6）
+
+## このファイルの位置付け
+
+原典 §4.2 Phase 2.6 を `worker` 担当の指示書として展開。Phase 2.4 (Amazon) / 2.5 (楽天) と独立並列可能。
+
+## 担当サービス
+
+`worker` コンテナ。Yahoo!ショッピングの注文確認メールを `Transaction` に正規化する `YahooMailAdapter`。**PayPay ポイント利用額を別フィールドで保持する**点が特徴（楽天ポイントと同じ思想だが別 EC）。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph2/03`（Gmail MCP）, `worker/Ph1/02`（IngestAdapter ABC） |
+| 下流 | `worker/Ph2/08`（cron） |
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.6（行 271-281）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **ADR**: `docs/adr/001-hybrid-ingestion-strategy.md`, `docs/adr/003-no-scraping.md`, `docs/adr/007-adapter-pattern.md`
+4. **既存資産**: `Transaction`, `compute_hash`, `RawMail`, `IngestAdapter` ABC
+5. **依存**: `mail-parser`, `beautifulsoup4`, `lxml`（既宣言）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/mail/yahoo.py` | `YahooMailAdapter` 実装 |
+| `tests/fixtures/mail/yahoo/normal.eml` | PayPay ポイントなし合成メール |
+| `tests/fixtures/mail/yahoo/with_paypay_points.eml` | PayPay ポイント利用あり |
+| `tests/fixtures/mail/yahoo/expected.json` | 期待 Transaction 配列 |
+| `tests/unit/adapters/mail/test_yahoo.py` | ゴールデンマスタ + PayPay ポイント + ハッシュ決定性 |
+
+## 実装方針
+
+1. **クラス**: `YahooMailAdapter(IngestAdapter)`、`source: ClassVar[str] = "yahoo_mail"`。
+2. **`parse(payload: RawMail | bytes) -> Iterable[Transaction]`**:
+   - `body_html` 優先、なければ `body_text`
+   - `BeautifulSoup(html, "lxml")` で抽出
+3. **抽出フィールド**:
+   - 注文番号（Yahoo!ショッピング独自フォーマット）
+   - 注文日
+   - 商品合計
+   - **PayPay ポイント利用額**
+   - 支払金額（= 商品合計 − ポイント）
+4. **金額符号**: 支払金額を `Transaction.amount` の **負値**として採用。
+5. **`raw_payload`**: 注文番号 / 商品合計 / PayPay ポイント利用額 / 支払金額を JSON で保持。
+6. **ハッシュ**: 注文番号を description に含める（Phase 2.4 / 2.5 と同じ規約）。
+7. **`extract_holdings`**: 空イテラブル。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/mail/yahoo/{normal,with_paypay_points}.eml` を合成。
+- `tests/fixtures/mail/yahoo/expected.json` に期待値。
+- `tests/unit/adapters/mail/test_yahoo.py`：
+  - ポイントなし: `raw_payload["paypay_points_used"] == "0"`
+  - ポイントあり: `raw_payload["paypay_points_used"] == "<利用額>"`
+  - 同一メール 2 回でハッシュ一致
+  - 注文番号別で別ハッシュ
+
+### 2. Green
+
+- `src/kakeibo/adapters/mail/yahoo.py` で `YahooMailAdapter` を最小実装。
+
+### 3. Refactor
+
+- Yahoo 独自の HTML 構造定数をモジュールトップレベル化。
+- Amazon / 楽天 との共通化は **しない**。
+
+## 受入条件
+
+- 通常 / PayPay ポイント利用ありの 2 パターンで `expected.json` と完全一致
+- PayPay ポイント利用額が `raw_payload["paypay_points_used"]` で別フィールド保持
+- 注文番号で冪等性が成立
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/mail/test_yahoo.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/parser-yahoo-mail`
+- コミット粒度（最低 3 件）：
+  1. `テスト: Yahooメールゴールデンマスタ（通常/PayPayポイント）テストを先行作成`
+  2. `機能: YahooMailAdapter本体（注文番号・金額・PayPayポイント抽出）を実装`
+  3. `機能: 支払金額算出とraw_payloadへのポイント情報保持を追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.6 Yahoo!ショッピング 注文確認メールパーサを実装。
+
+## 成果物
+- src/kakeibo/adapters/mail/yahoo.py
+- tests/fixtures/mail/yahoo/{normal,with_paypay_points}.eml
+- tests/fixtures/mail/yahoo/expected.json
+- tests/unit/adapters/mail/test_yahoo.py
+
+## 検証結果
+- 全件緑（2 パターン）
+- pyright / ruff: クリーン
+
+## 次のアクション提案
+worker/Ph2/04, 05 完了を待って worker/Ph2/08 へ。
+```
+
+## 注意事項
+
+- **スクレイピング禁止**（ADR-003）: メール本文以外（Yahoo!ショッピングのマイページ）から取得しない。
+- **実注文情報を fixture に含めない**: 注文番号・氏名・住所・商品名は合成。
+- PayPay ポイントと PayPay 残高は別物。本タスクは **ポイント利用** のみ扱い、PayPay 残高決済は Phase 2.7 PayPal API とも別レーン（PayPay 残高は `compose.yml` に未準備のため Phase 4 以降で評価）。
+- 3 EC（Amazon / 楽天 / Yahoo）でメール構造が大きく異なる。共通化リファクタは Phase 4 以降で評価。

--- a/docs/plans/worker/Ph2/07-adapter-paypal-api.md
+++ b/docs/plans/worker/Ph2/07-adapter-paypal-api.md
@@ -1,0 +1,158 @@
+---
+title: worker/Ph2/07 PayPal Transactions API クライアント
+service: worker
+phase_task_id: 2.7
+priority: 高
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.7（行 283-293）
+branch: feature/adapter-paypal-api
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/07 PayPal Transactions API クライアント（Phase 2.7）
+
+## このファイルの位置付け
+
+原典 §4.2 Phase 2.7 を `worker` 担当の指示書として展開。Phase 2.3〜2.6 とは **完全独立**（OAuth ではなく API Secret、メールではなく REST API）。Phase2 完了条件 (c)「PayPal Sandbox から取引取得」を直接満たす。
+
+## 担当サービス
+
+`worker` コンテナ。PayPal Transactions API v1（Sandbox / Live 両対応）を叩いて日次取引を取得し、`Transaction` に正規化する `PaypalApiAdapter`。レート制限（HTTP 429）に対する **指数バックオフ** を実装する。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph1/02`（IngestAdapter ABC） |
+| 下流 | `worker/Ph2/08`（cron バッチ） |
+
+`worker/Ph2/03〜06` と完全独立。
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.7（行 283-293）
+2. **アダプタ設計**: `worker/docs/design/02-ingest-adapters.md`
+3. **セキュリティ**: `docs/design/05-security-model.md`
+4. **ADR**: `docs/adr/007-adapter-pattern.md`, `docs/adr/011-no-credentials-storage.md`
+5. **既存資産**:
+   - `compose.yml` `worker` の secret `paypal_api_secret`、環境変数 `PAYPAL_API_SECRET_FILE=/run/secrets/paypal_api_secret`
+   - `secrets/paypal_api_secret.txt.example`（フォーマット参考）
+   - `src/kakeibo/config.py` の `paypal_api_secret: str | None` フィールド
+6. **依存**: `httpx`（既宣言、`[project.dependencies]`）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `src/kakeibo/adapters/paypal.py` | `PaypalApiAdapter` 実装 |
+| `src/kakeibo/adapters/_http.py` | 指数バックオフ付き HTTP クライアントヘルパ（PayPal 専用 or 汎用） |
+| `tests/fixtures/paypal/sample_transaction_response.json` | PayPal API レスポンスの fixture |
+| `tests/fixtures/paypal/rate_limit_response.json` | HTTP 429 レスポンス fixture |
+| `tests/unit/adapters/test_paypal.py` | API モック + レート制限リトライ + 冪等性 |
+
+## 実装方針
+
+1. **クラス**: `PaypalApiAdapter(IngestAdapter)`、`source: ClassVar[str] = "paypal"`。
+2. **認証フロー**:
+   - `Settings.paypal_api_secret` から API Secret を読込
+   - `client_id` は環境変数 `PAYPAL_CLIENT_ID`（compose.yml に追加 or `.env.example` に追記）
+   - `POST /v1/oauth2/token` で **アクセストークン取得**（client_credentials grant）
+   - アクセストークンの有効期限を保持し、期限切れで再取得
+3. **取引取得**:
+   - `GET /v1/reporting/transactions?start_date=...&end_date=...&fields=all`
+   - 日付範囲は **取得時点の前日 0:00 UTC 〜 当日 0:00 UTC**（半開区間）の 1 日分を基本単位
+4. **`Transaction` 正規化**:
+   - `transaction_info.transaction_id` → description 末尾に含める（冪等性キー）
+   - `transaction_info.transaction_amount.value` → `Decimal` で `amount`（`PaymentSent` 系は負、`PaymentReceived` 系は正に正規化）
+   - `transaction_info.transaction_initiation_date` → `occurred_at`
+   - 通貨コード → `currency`
+5. **レート制限ハンドリング**: HTTP 429 で `Retry-After` ヘッダがあれば従う、なければ指数バックオフ（1 → 2 → 4 → 8 秒、最大 4 回）。失敗時は `AdapterError("PayPal rate limit exceeded")`。
+6. **`extract_holdings`**: 空イテラブル。
+7. **シークレット非露出**: `httpx` のリクエスト/レスポンスログ出力で `Authorization` ヘッダがマスクされること。`structlog` カスタムプロセッサで除去。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/fixtures/paypal/sample_transaction_response.json` を Sandbox の実フォーマットに合わせて合成（実取引情報は禁止）。
+- `tests/fixtures/paypal/rate_limit_response.json` で HTTP 429 + `Retry-After: 1` 形式。
+- `tests/unit/adapters/test_paypal.py`：
+  - 正常系: モック HTTP で 200 → `Transaction` リスト返却
+  - レート制限: 1 回目 429 → 2 回目 200、ハンドリングが期待通り（スリープモック）
+  - レート制限が 4 回連続で `AdapterError`
+  - 冪等性: 同一 transaction_id で 2 回パースしてハッシュ一致
+  - `Authorization` ヘッダがログに出ない
+
+### 2. Green
+
+- `src/kakeibo/adapters/_http.py` で `httpx.Client` をラップした `_request_with_backoff(method, url, **kwargs)` を実装。
+- `src/kakeibo/adapters/paypal.py` で OAuth トークン取得 → 取引一覧取得 → `Transaction` 変換。
+- 各テストを順に通す。
+
+### 3. Refactor
+
+- `_http.py` を **PayPal 専用にせず汎用化**（Phase 2.3 Gmail でも HTTP モックが必要なため）。Gmail との共通利用を検討。
+- レート制限ハンドリングを `_RetryPolicy` dataclass にまとめてテスト容易化。
+
+## 受入条件
+
+- Sandbox 環境で日次取引が取得できる（実 Sandbox はオプション、テストは fixtures で代替）
+- API Secret が `Settings.paypal_api_secret` 経由（Docker secret）でのみ読み込まれる
+- レート制限時の指数バックオフが実装されている（最大 4 回 / `Retry-After` 優先）
+- 取引 ID で冪等性が成立する（同一 transaction_id で行数増えず）
+- `Authorization` ヘッダがログに出力されない（`caplog` で検証）
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/adapters/test_paypal.py
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/adapter-paypal-api`
+- コミット粒度（最低 5 件）：
+  1. `テスト: PayPal API正常系/レート制限/冪等性/シークレット非露出のテストを先行作成`
+  2. `機能: 指数バックオフ付きHTTPクライアントヘルパを追加`
+  3. `機能: PayPal OAuth2トークン取得とアクセストークンキャッシュを実装`
+  4. `機能: PaypalApiAdapter本体（取引取得・Transaction変換）を実装`
+  5. `機能: 構造化ログでAuthorizationヘッダをマスクするプロセッサを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.7 PayPal Transactions API クライアントを実装。
+
+## 成果物
+- src/kakeibo/adapters/paypal.py
+- src/kakeibo/adapters/_http.py
+- tests/fixtures/paypal/{sample_transaction_response,rate_limit_response}.json
+- tests/unit/adapters/test_paypal.py
+
+## 検証結果
+- 全件緑（モック含む）
+- レート制限ハンドリング動作確認
+- caplog で Authorization 非露出を確認
+- pyright / ruff: クリーン
+
+## 既知の課題・申し送り
+- 実 Sandbox 環境での試験は別途 secrets 整備後に運用検証として実施。
+
+## 次のアクション提案
+worker/Ph2/04, 05, 06, 07 が揃った時点で worker/Ph2/08 (cron) へ。
+```
+
+## 注意事項
+
+- **API Secret をコードリテラルに書かない**。`Settings.paypal_api_secret` 経由で必ず読み込む。Git に絶対コミットしない。
+- **Sandbox / Live の切替**: `PAYPAL_API_BASE` 環境変数で切替可能にする（Sandbox: `https://api-m.sandbox.paypal.com`、Live: `https://api-m.paypal.com`）。
+- **クライアント ID の管理**: `client_id` は `secret` ではなく **公開可能な識別子** だが、`.env.example` に placeholder のみ書き、実値は環境ごとに設定する。
+- **レート制限ポリシー**: `Retry-After` ヘッダがあれば優先、なければ指数バックオフ。最大リトライ数 4 を超えたら諦めて例外送出（過剰リトライによる課金 / アカウント制限を避ける）。
+- **取引種別の符号**: PayPal API は `PaymentSent` / `PaymentReceived` 等で取引方向を示すが、`amount.value` の符号も同じ意味で出てくる。**`amount.value` の符号をそのまま採用**（独自に反転させない）。
+- 日付境界は **UTC** で固定。タイムゾーン揺れを避ける。

--- a/docs/plans/worker/Ph2/08-cron-batch-runner.md
+++ b/docs/plans/worker/Ph2/08-cron-batch-runner.md
@@ -1,0 +1,156 @@
+---
+title: worker/Ph2/08 cron バッチ運用化
+service: worker
+phase_task_id: 2.8
+priority: 中
+source_plan: docs/plans/01-development-plan.md
+source_section: §4.2 Phase 2.8（行 295-305）
+branch: feature/cron-batch-runner
+base_branch: develop
+status: Ready
+last_updated: 2026-05-01
+---
+
+# worker/Ph2/08 cron バッチ運用化（Phase 2.8）
+
+## このファイルの位置付け
+
+原典 §4.2 Phase 2.8 を `worker` 担当の指示書として展開。Phase 2.4〜2.7 のすべてが **完了** していることが前提。Gmail 取込（Amazon / 楽天 / Yahoo）と PayPal 取込を **日次バッチ**として運用に組み込む最終タスク。
+
+## 担当サービス
+
+`worker` コンテナ。`worker/Dockerfile` への cron 関連改修と、`src/kakeibo/worker/scheduler.py` バッチ実行エントリポイントを実装する。`compose.yml` の `worker` サービスは引き続き常駐し、内部で cron が日次トリガを発火する形（Phase 0 の heartbeat ループ + Watcher + cron の三層常駐構造）。
+
+## 上流・下流
+
+| 区分 | タスク |
+|---|---|
+| 上流 | `worker/Ph2/04`, `05`, `06`（メールパーサ）, `worker/Ph2/07`（PayPal） |
+| 下流 | Phase 4.x（LLM 分類 / Reconciler 等が本バッチに新規ジョブを追加する想定） |
+
+## 入力
+
+1. **原典**: §4.2 Phase 2.8（行 295-305）
+2. **デプロイ**: `docs/design/04-deployment-stack.md`
+3. **取込フロー**: `worker/docs/design/08-ingest-flow.md`
+4. **ADR**: `docs/adr/009-nas-docker-compose.md`
+5. **既存資産**:
+   - `worker/Dockerfile`（uv マルチステージ、`USER kakeibo` で非 root）
+   - `src/kakeibo/worker/main.py`（heartbeat ループ + `worker/Ph2/01` で Watcher 統合済み）
+   - 各種 Adapter（`worker/Ph2/03〜07`）
+6. **依存追加検討**: `apscheduler>=3.10,<4` を `[project.dependencies]` に追加（cron 起動を **Python プロセス内**で行う方式を推奨。OS の cron デーモンを別途立てる方式より監査・テストが容易）
+
+## 期待される出力ファイル
+
+| パス | 役割 |
+|---|---|
+| `pyproject.toml` | `apscheduler>=3.10,<4` 追加 |
+| `src/kakeibo/worker/scheduler.py` | APScheduler ベースのジョブ登録 + 起動 |
+| `src/kakeibo/worker/jobs/__init__.py` | パッケージ |
+| `src/kakeibo/worker/jobs/gmail_ingest.py` | Gmail 取込ジョブ（Amazon / 楽天 / Yahoo を順に実行） |
+| `src/kakeibo/worker/jobs/paypal_ingest.py` | PayPal 取込ジョブ |
+| `src/kakeibo/worker/main.py` | `run()` の中で Scheduler を起動（既存 API 互換維持） |
+| `tests/unit/worker/test_scheduler.py` | ジョブ登録 / トリガ時刻 / 実行ログ |
+| `tests/unit/worker/test_gmail_ingest_job.py` | Gmail ジョブが冪等に動く |
+| `tests/unit/worker/test_paypal_ingest_job.py` | PayPal ジョブが冪等に動く |
+| `tests/integration/scheduler/test_scheduler_e2e.py` | 短い間隔でジョブを発火させて DB 反映を確認 |
+
+## 実装方針
+
+1. **APScheduler 採用理由**: OS の cron デーモンを `worker` コンテナに同居させると、非 root 運用と PID 1 のシグナルハンドリングが複雑化する。Python プロセス内 scheduler ならテストとログが統一できる。
+2. **トリガ時刻**:
+   - Gmail 取込: 毎日 03:00 JST（`CronTrigger(hour=3, minute=0, timezone="Asia/Tokyo")`）
+   - PayPal 取込: 毎日 03:30 JST
+3. **ジョブの冪等性**: 各ジョブは `worker/Ph2/04〜07` の Adapter を呼び、`worker/Ph1/05` の `persister.persist(transactions)` で DB に永続化（`ON CONFLICT (hash) DO NOTHING`）。**連続実行で重複取引が発生しない**ことをテストで保証。
+4. **失敗時のログ**: `structlog` で構造化ログ。`event=job_failed`, `job_name=...`, `error_class=...`, `traceback=...`。stdout / stderr 経由で Docker のログドライバへ流す。
+5. **graceful shutdown**: `BackgroundScheduler.shutdown(wait=True)` を SIGTERM ハンドラから呼ぶ。実行中ジョブの完了待ち（最大 30 秒）→ 強制終了。
+6. **`worker/Dockerfile` 改修**: 原則 **不要**（Python プロセス内 scheduler のため）。CMD は `python -m kakeibo.worker` のまま。
+7. **テスト戦略**: APScheduler の `BackgroundScheduler` は **同期実行に切替えてテスト**（`scheduler.add_job(..., next_run_time=datetime.now())` + `scheduler.start()` + `scheduler.shutdown(wait=True)`）。
+
+## 実装手順（TDD）
+
+### 1. Red
+
+- `tests/unit/worker/test_scheduler.py`：
+  - `register_jobs(scheduler)` が 2 ジョブ登録（gmail / paypal）
+  - `CronTrigger` の時刻が期待通り
+  - SIGTERM 相当で graceful shutdown
+- `tests/unit/worker/test_gmail_ingest_job.py`：
+  - モック Gmail クライアント + モック persister で `gmail_ingest_job()` が Amazon / 楽天 / Yahoo の順に呼ばれる
+  - 連続 2 回実行で永続化呼び出し回数は同じだが行数増加なし（モック persister の `ON CONFLICT` 模倣）
+- `tests/unit/worker/test_paypal_ingest_job.py`：同様に PayPal 単独。
+- `tests/integration/scheduler/test_scheduler_e2e.py`：testcontainers Postgres + 短い `next_run_time` で実発火 → DB 反映確認。
+
+### 2. Green
+
+- `pyproject.toml` に `apscheduler` 追加 + `uv sync`。
+- `src/kakeibo/worker/jobs/{gmail_ingest,paypal_ingest}.py` を最小実装。
+- `src/kakeibo/worker/scheduler.py` で `register_jobs(scheduler) -> None` と `build_scheduler() -> BackgroundScheduler` を実装。
+- `src/kakeibo/worker/main.py` の `run()` で Scheduler を起動 + heartbeat ループ + Watcher と並行常駐。
+
+### 3. Refactor
+
+- ジョブ共通の例外ハンドリング（ログ書き出し → 例外を握り潰さない）を `_run_with_logging(job_fn, *, job_name)` に抽出。
+- トリガ設定を `_build_triggers(settings: Settings) -> dict[str, CronTrigger]` に集約してテスト容易化。
+
+## 受入条件
+
+- `docker compose up -d` で `worker` コンテナ内で日次 cron が起動状態（`docker compose exec worker python -c "..."` で scheduler 状態確認可能）
+- バッチ失敗時に構造化ログが残る（`event=job_failed` を含む）
+- 連続実行で重複取引が発生しない（`hash` UNIQUE で吸収）
+- SIGTERM で graceful shutdown（実行中ジョブ完了待ち 30 秒以内）
+- heartbeat / Watcher と並行して動作する
+- `pyright` クリーン、`ruff` 違反ゼロ
+
+## 品質ゲート
+
+```bash
+pytest tests/unit/worker/ tests/integration/scheduler/
+ruff check .
+pyright
+```
+
+## ブランチ・コミット規約
+
+- ブランチ: `feature/cron-batch-runner`
+- コミット粒度（最低 5 件）：
+  1. `テスト: scheduler登録・冪等ジョブ実行・graceful shutdownのテストを先行作成`
+  2. `設定: apscheduler依存パッケージをpyproject.tomlに追加`
+  3. `機能: Gmail取込ジョブ（Amazon/楽天/Yahoo順次起動）を実装`
+  4. `機能: PayPal取込ジョブを実装`
+  5. `機能: APScheduler起動とworkerメインループ統合・graceful shutdownを追加`
+
+## 完了報告テンプレ
+
+```markdown
+## 実施内容
+Phase 2.8 cron バッチ運用化を実装。
+
+## 成果物
+- pyproject.toml（apscheduler 追加）
+- src/kakeibo/worker/scheduler.py
+- src/kakeibo/worker/jobs/{gmail_ingest,paypal_ingest}.py
+- src/kakeibo/worker/main.py（拡張）
+- tests/unit/worker/{test_scheduler,test_gmail_ingest_job,test_paypal_ingest_job}.py
+- tests/integration/scheduler/test_scheduler_e2e.py
+
+## 検証結果
+- 全件緑（unit + integration）
+- 連続実行で重複取引なし
+- graceful shutdown 動作確認
+- pyright / ruff: クリーン
+
+## Phase 2 完了状況
+Phase2 完了条件 (a) (b) (c) (d) (e) すべて達成。Phase 3 着手準備が整った。
+
+## 次のアクション提案
+docs/plans/{api,ui}/Ph3/ 配下に Phase 3 タスク指示書を生成する。
+```
+
+## 注意事項
+
+- **OS cron デーモン併設は採用しない**: 非 root 運用 + PID 1 シグナル処理が複雑になるため、APScheduler in-process 方式で統一。
+- **タイムゾーン**: cron トリガは `Asia/Tokyo` 指定だが、内部処理（PayPal の日付範囲など）は **UTC で固定**（タイムゾーン揺れ防止）。
+- **ジョブ重複起動禁止**: APScheduler の `max_instances=1` をジョブごとに設定。前回実行が遅延しても多重実行しない。
+- **secrets 不在時の挙動**: 開発ホスト等で `gmail_oauth_token` / `paypal_api_secret` が未配置の場合、scheduler 起動は成功するがジョブ実行時に `RuntimeError` を出して停止。**サイレントに失敗させない**。
+- **Watcher との競合なし**: Watcher は inbox の CSV 取込、cron は Gmail / PayPal の API 取込で経路が完全分離。同じ `transactions.hash` で UNIQUE 衝突しても `ON CONFLICT DO NOTHING` で吸収される。

--- a/docs/plans/worker/Ph2/README.md
+++ b/docs/plans/worker/Ph2/README.md
@@ -1,0 +1,110 @@
+---
+title: worker サービス Phase2 タスク指示書
+service: worker
+phase: 2
+status: Ready
+parent_index: docs/plans/12-phase2-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# worker サービス Phase2 タスク指示書
+
+`compose.yml` `worker` サービス（Phase1 で取込パイプラインのコア層を実装した上に、Phase2 では **自動取込基盤**を積み上げる）。Phase2 の 8 タスクすべてが本サービスに帰属する。
+
+## サービス境界（Phase2 で本ディレクトリが扱うもの）
+
+| 範囲 | パス |
+|---|---|
+| watchdog Watcher（inbox 監視） | `src/kakeibo/ingest/watcher.py` |
+| アーカイブ移動 / dead letter ロジック | `src/kakeibo/ingest/archiver.py` |
+| Gmail MCP クライアント + `RawMail` 共通型 | `src/kakeibo/adapters/gmail/`, `src/kakeibo/domain/raw_mail.py` |
+| メールパーサ群（Amazon / 楽天 / Yahoo） | `src/kakeibo/adapters/mail/{amazon,rakuten,yahoo}.py` |
+| PayPal API クライアント | `src/kakeibo/adapters/paypal.py` |
+| cron バッチランナー / scheduler | `src/kakeibo/worker/scheduler.py`, `worker/Dockerfile`（cron 関連改修） |
+| Phase2 統合テスト | `tests/integration/{watcher,archiver,mail,paypal,scheduler}/` |
+| メール fixture（合成 .eml） | `tests/fixtures/mail/{amazon,rakuten,yahoo}/*.eml` |
+
+### このディレクトリでは扱わないもの
+
+| 対象 | 帰属 |
+|---|---|
+| DB スキーマの追加変更 | `postgres/`（Phase2 ではスキーマ変更なし） |
+| REST API / UI | `api/Ph3/`, `ui/Ph3/`（Phase 3 で着手） |
+| LLM 分類 / Reconciler | Phase 4（`docs/plans/01-development-plan.md` §4.4） |
+
+## タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典（行） | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 2.1 watchdog Watcher サービス | [`01-watcher-service.md`](./01-watcher-service.md) | §4.2 L211-221 | `feature/watcher-service` | 🔴 高 |
+| 02 | Phase 2.2 アーカイブ + dead letter | [`02-archive-and-dead-letter.md`](./02-archive-and-dead-letter.md) | §4.2 L223-233 | `feature/archive-and-dead-letter` | 🟠 中 |
+| 03 | Phase 2.3 Gmail MCP 接続 | [`03-gmail-mcp-client.md`](./03-gmail-mcp-client.md) | §4.2 L235-245 | `feature/gmail-mcp-client` | 🔴 高 |
+| 04 | Phase 2.4 Amazon メールパーサ | [`04-parser-amazon-mail.md`](./04-parser-amazon-mail.md) | §4.2 L247-257 | `feature/parser-amazon-mail` | 🟡 中 |
+| 05 | Phase 2.5 楽天市場 メールパーサ | [`05-parser-rakuten-mail.md`](./05-parser-rakuten-mail.md) | §4.2 L259-269 | `feature/parser-rakuten-mail` | 🟡 中 |
+| 06 | Phase 2.6 Yahoo!ショッピング メールパーサ | [`06-parser-yahoo-mail.md`](./06-parser-yahoo-mail.md) | §4.2 L271-281 | `feature/parser-yahoo-mail` | 🟡 中 |
+| 07 | Phase 2.7 PayPal API クライアント | [`07-adapter-paypal-api.md`](./07-adapter-paypal-api.md) | §4.2 L283-293 | `feature/adapter-paypal-api` | 🔴 高 |
+| 08 | Phase 2.8 cron バッチ運用化 | [`08-cron-batch-runner.md`](./08-cron-batch-runner.md) | §4.2 L295-305 | `feature/cron-batch-runner` | 🟠 中 |
+
+## 実行順序（推奨直列 + 並列）
+
+```
+[Phase1 完了] ←必須前提
+   ↓
+worker/Ph2/01 (Watcher) ─→ worker/Ph2/02 (Archive/DLQ)
+worker/Ph2/03 (Gmail) ─┬─→ worker/Ph2/04 (Amazon)
+                       ├─→ worker/Ph2/05 (Rakuten)
+                       └─→ worker/Ph2/06 (Yahoo)
+worker/Ph2/07 (PayPal)
+                                         ↓
+                           worker/Ph2/08 (cron; 04/05/06/07 完了後)
+```
+
+並列の機会：
+- `01 (Watcher)` と `03 (Gmail)` は独立 → 別 Coder で並列可
+- `04 / 05 / 06` は Gmail MCP 完了後に 3 並列可
+- `07 (PayPal)` は他レーンと完全独立
+
+## 共通の前提
+
+- **Phase1 完了が必須**（`worker/Ph1/01〜07` と `postgres/Ph1/01` が緑）
+- `pyproject.toml` の dependencies / dev / mail extras は宣言済み（追加は最小限）
+- secrets ファイルは `secrets/*.example` を参考にローカル開発用にコピーして使用（実値は git に絶対コミットしない）
+- `compose.yml` の `worker` 環境変数（`INBOX_PATH`, `GMAIL_OAUTH_TOKEN_FILE` など）は変更不要（既宣言）
+
+## 担当 Worker サブエージェント（モードB前提）
+
+`agent-rules/91-claude-subagent-coding.md` に従う。
+
+| Worker | 主な責務 |
+|---|---|
+| Planner | Watcher の責務分割、メールパーサの fixture 設計、cron スケジュール設計 |
+| Coder | テスト先行 → 実装。Watcher/Archiver は統合テスト中心、メールパーサはゴールデンマスタ |
+| Reviewer | OAuth スコープが `gmail.readonly` 限定か、トークン・シークレットがログに漏れないか、冪等性、レート制限ハンドリング |
+| Git-composer | アトミックコミット、`feature/*` ブランチ運用 |
+
+並列ポリシー: `04/05/06` は同一メッセージ内に 3 体の Coder Task を並列起動可（同一ファイルへの競合なし）。
+
+## 共通の品質ゲート
+
+```bash
+pytest tests/unit/ tests/integration/   # 該当範囲緑（統合は 5 分以内）
+ruff check .
+pyright
+```
+
+統合確認（`08-cron-batch-runner.md` 完了後）：
+- `/inbox` への CSV 投下から 5 分以内に DB 反映
+- 模擬メール 3 EC で取引抽出
+- PayPal Sandbox 取引取得
+- 失敗ファイルが dead_letter へ移動
+- cron 連続実行で重複取引なし
+
+## Phase2 完了条件カバレッジ
+
+| 完了条件 | 主担当タスク |
+|---|---|
+| (a) Watcher 5 分以内 DB 反映 | `01` + `02` |
+| (b) EC メール取引抽出 | `04` + `05` + `06`（基盤: `03`） |
+| (c) PayPal Sandbox 取引取得 | `07` |
+| (d) 失敗ファイル → dead_letter | `02` |
+| (e) 統合テスト緑 | 全タスク横断 |

--- a/docs/plans/worker/Ph3/README.md
+++ b/docs/plans/worker/Ph3/README.md
@@ -1,0 +1,61 @@
+---
+title: worker サービス Phase3 タスク指示書
+service: worker
+phase: 3
+status: NoTasks
+parent_index: docs/plans/13-phase3-service-assignments.md
+last_updated: 2026-05-01
+---
+
+# worker サービス Phase3 タスク指示書
+
+## 結論：Phase3 では本サービス向けの新規実装タスクなし
+
+`compose.yml` `worker` サービスは Phase 1〜2 で取込パイプライン（CLI / Watcher / メールパーサ / PayPal API / cron バッチ）が完成する設計。Phase 3 は **「すでに DB に蓄積された取引データ」を REST API + UI で可視化する**フェーズのため、worker 側の取込ロジックには手を入れない。
+
+`docs/plans/01-development-plan.md` §4.3 のタスク 3.1〜3.6 をすべて確認しても、worker サービスの実装を変更する項目はない。
+
+## サービス境界（参考）
+
+| 範囲 | パス | Phase 3 での扱い |
+|---|---|---|
+| 取込CLI | `src/kakeibo/ingest/cli.py` | 変更なし |
+| Watcher / Archiver | `src/kakeibo/ingest/{watcher,dispatch,archiver}.py` | 変更なし |
+| メールパーサ群 | `src/kakeibo/adapters/mail/` | 変更なし |
+| PayPal API クライアント | `src/kakeibo/adapters/paypal.py` | 変更なし |
+| Scheduler / Jobs | `src/kakeibo/worker/{scheduler,jobs/}.py` | 変更なし |
+| `worker/Dockerfile` | – | 変更なし |
+
+## Phase3 の間に worker サービスへ波及する変更（許容例）
+
+| 変更例 | 受入可否 | 備考 |
+|---|---|---|
+| `pyproject.toml` `[project.dependencies]` への追加（`flask-smorest`, `marshmallow`） | 可（再ビルド必要） | `api/Ph3/01` で発生。worker イメージにも反映されるが起動時は import されない |
+| `src/kakeibo/__init__.py` の `__version__` 更新 | 可 | リリース時の同期 |
+| `src/kakeibo/config.py` への認証バイパスフラグ追加 | 慎重に | `api/Ph3/01` で `KAKEIBO_API_AUTH_BYPASS` を Settings に追加する際、worker では参照しないが既存テスト（`tests/unit/test_settings_repr.py`）を壊さないこと |
+| `worker/Dockerfile` 変更 | 不要 | – |
+
+`agent-rules/00-core-principles.md` の3原則 §1 デグレッション防止と整合：既存の取込パイプラインの動作・既存テストを壊さないこと。
+
+## Phase 4 への申し送り
+
+Phase 4 で本サービスに変更が必要となる候補：
+
+- **Phase 4.1 LLM 分類サービス**: `api/Ph3/03` で実装される `src/kakeibo/categorizer/rules.py` を再利用しつつ、未マッチ取引を Anthropic API に投げて分類するワーカージョブを `src/kakeibo/worker/jobs/llm_classify.py` として追加
+- **Phase 4.2 半自動学習**: ルール提案ジョブを `src/kakeibo/worker/jobs/rule_suggest.py` として追加
+- **Phase 4.3 Reconciler**: 連動取引マージのワーカージョブ
+- **Phase 4.4 残高整合性レポート**: 日次整合性チェックジョブ
+- **Phase 4.5 Obsidian 月次出力**: 月次バッチで Markdown 出力
+
+これらは Phase 4 着手時に `docs/plans/worker/Ph4/` を新設して扱う。
+
+## 担当 Worker サブエージェント
+
+Phase3 期間中の起動は **Reviewer のみ**：
+
+| Worker | 役割 |
+|---|---|
+| Reviewer | `api/Ph3/01` で `pyproject.toml` に `flask-smorest` / `marshmallow` が追加されたとき、`worker` コンテナのビルド・起動・既存テスト（`tests/unit/`, `tests/integration/`）が壊れないことを Read のみで確認 |
+| Reviewer | `api/Ph3/03` で実装される `src/kakeibo/categorizer/rules.py` が、Phase 4.1 LLM 分類との接合点として再利用しやすい設計か（責務分離・依存方向）を確認 |
+
+Coder / Planner / Git-composer の起動は Phase3 では原則不要。

--- a/docs/plans/worker/README.md
+++ b/docs/plans/worker/README.md
@@ -1,0 +1,107 @@
+---
+title: worker サービス Phase1 タスク指示書
+service: worker
+phase: 1
+status: Ready
+parent_index: docs/plans/10-phase1-overview.md
+last_updated: 2026-05-01
+---
+
+# worker サービス Phase1 タスク指示書
+
+`compose.yml` の `worker` サービスに帰属する Phase1 タスク群（1.2〜1.8）。Phase1 の **アプリケーションロジックの大部分** がこのサービスに集約される。
+
+## サービス境界（このディレクトリで扱うもの）
+
+| 範囲 | パス |
+|---|---|
+| ドメイン共通型（Transaction / Holding / BalanceSnapshot / `compute_hash`） | `src/kakeibo/domain/` |
+| 取込アダプタ抽象基底 | `src/kakeibo/adapters/base.py`, `errors.py` |
+| MUFG / SMBC CSV 機関別アダプタ | `src/kakeibo/adapters/mufg.py`, `smbc.py` |
+| 取込 CLI（`python -m kakeibo.ingest`） | `src/kakeibo/ingest/cli.py`, `registry.py`, `persister.py` |
+| 月次サマリ SQL のクエリファイルとアプリ層ランナー | `sql/queries/monthly_summary.sql`, `src/kakeibo/sql/runner.py` |
+| ハッシュ冪等性 property-based test | `tests/unit/domain/test_hash.py`, `test_hash_boundary.py` |
+| 取込パイプライン全般のユニットテスト | `tests/unit/{domain,adapters,ingest,sql}/` |
+
+実行時は `worker` コンテナ（`worker/Dockerfile` が `src/kakeibo` を COPY）の `python -m kakeibo.ingest <institution> <path>` などから起動する。Phase 2.1 で watchdog Watcher に発展する基盤。
+
+### このディレクトリでは扱わないもの
+
+| 対象 | 帰属サービス |
+|---|---|
+| Alembic マイグレーション本体 | `postgres` サービス（`docs/plans/postgres/`） |
+| Flask REST API | `api` サービス（Phase 0 完了済み、Phase 3.1 で本格着手） |
+| Next.js UI | `ui` サービス（Phase 3.2 から） |
+
+## タスク一覧
+
+| 連番 | 担当タスク | 指示書 | 原典プラン | ブランチ | 優先度 |
+|---|---|---|---|---|---|
+| 01 | Phase 1.2 ドメイン共通型 | [`01-domain-types.md`](./01-domain-types.md) | `docs/plans/03-phase1-domain-types.md` | `feature/domain-types` | 🔴 高 |
+| 02 | Phase 1.3 IngestAdapter ABC | [`02-ingest-adapter-base.md`](./02-ingest-adapter-base.md) | `docs/plans/04-phase1-ingest-adapter-base.md` | `feature/ingest-adapter-base` | 🔴 高 |
+| 03 | Phase 1.4 MUFG CSV アダプタ | [`03-mufg-csv-adapter.md`](./03-mufg-csv-adapter.md) | `docs/plans/05-phase1-mufg-csv-adapter.md` | `feature/adapter-mufg-csv` | 🟡 中 |
+| 04 | Phase 1.5 SMBC CSV アダプタ | [`04-smbc-csv-adapter.md`](./04-smbc-csv-adapter.md) | `docs/plans/06-phase1-smbc-csv-adapter.md` | `feature/adapter-smbc-csv` | 🟡 中 |
+| 05 | Phase 1.6 取込CLI | [`05-ingest-cli.md`](./05-ingest-cli.md) | `docs/plans/07-phase1-ingest-cli.md` | `feature/ingest-cli` | 🔴 高 |
+| 06 | Phase 1.7 ハッシュ冪等性テスト強化 | [`06-hash-idempotency-tests.md`](./06-hash-idempotency-tests.md) | `docs/plans/08-phase1-hash-idempotency-tests.md` | `feature/hash-idempotency-tests` | 🟡 中 |
+| 07 | Phase 1.8 月次サマリ SQL | [`07-monthly-summary-sql.md`](./07-monthly-summary-sql.md) | `docs/plans/09-phase1-monthly-summary-sql.md` | `feature/monthly-summary-sql` | 🟡 中 |
+
+## 実行順序（推奨直列）
+
+`docs/plans/10-phase1-overview.md` §3 と整合：
+
+```
+[postgres/01]
+   ↓
+worker/01 (1.2) → worker/02 (1.3) ┬─→ worker/03 (1.4) ┐
+                                  └─→ worker/04 (1.5) ┴─→ worker/05 (1.6)
+                                                              ├─→ worker/06 (1.7)
+                                                              └─→ worker/07 (1.8)
+```
+
+並行可能ペア：
+- `worker/03 (1.4 MUFG)` と `worker/04 (1.5 SMBC)` は独立 → 別 Worker 並列起動可
+- `worker/06 (1.7)` と `worker/07 (1.8)` は CLI 完了後に独立並列可
+
+## 共通の前提
+
+- Python 3.12 / `pyproject.toml` の `[project.dependencies]` を使用。`click`, `httpx`, `pydantic`, `psycopg`, `sqlalchemy`, `structlog` はインストール済み。
+- 開発依存（dev extras）に `pytest`, `hypothesis`, `testcontainers`, `pyright`, `ruff` 宣言済み。
+- 取込パイプラインは **dataclass + Raw SQL** を基本（`agent-rules/01-claude-behavior.md` のシンプルさ優先方針、`docs/plans/03-phase1-domain-types.md` §実装方針 1 「pydantic を入れない」）。
+- `compute_hash` は `src/kakeibo/domain/transaction.py` に実装し、機関別アダプタは **再実装禁止**（`docs/plans/05-phase1-mufg-csv-adapter.md` §実装方針 7）。
+
+## 担当 Worker サブエージェント（モードB前提）
+
+`agent-rules/91-claude-subagent-coding.md` に従い、メインClaudeはオーケストレーターに徹する。
+
+| Worker | 主な責務 |
+|---|---|
+| Planner | 各タスクの実装範囲確認、影響ファイル列挙、ADR との整合確認 |
+| Coder | テスト先行 → 最小実装 → リファクタ。各タスクごとに 1 ブランチ・複数コミット |
+| Reviewer | アダプタ間の独立性、`compute_hash` の決定性、CLI 終了コード規約、`ON CONFLICT` の冪等性、SQL の境界条件 |
+| Git-composer | `agent-rules/10-git-strategy.md` 準拠のアトミックコミット、`feature/*` ブランチ運用 |
+
+並列実行ポリシー: `worker/03` と `worker/04` は同一メッセージ内で 2 体の Coder を並列起動可。
+
+## 共通の品質ゲート
+
+各タスク完了時：
+
+```bash
+pytest tests/unit/                   # 該当範囲が全件緑（10 秒以内）
+ruff check .                         # 違反ゼロ
+pyright                              # 警告ゼロ
+```
+
+統合確認（`worker/05` 完了後）：
+- 実 Postgres（testcontainers）に対して取込 CLI が成功
+- 同一 CSV 2 回投入で行数増えず（Phase1 完了条件 (b)）
+- `worker/07` 完了後、月次サマリ SQL が手計算と一致（完了条件 (c)）
+
+## Phase1 完了条件カバレッジ
+
+| 完了条件（`docs/plans/01-development-plan.md` §3.1） | 担当タスク |
+|---|---|
+| (a) `alembic upgrade head` 冪等 | `postgres/01` |
+| (b) 同一 CSV 2 回投入で行数増えず | `worker/05` + `worker/06` |
+| (c) 月次サマリ SQL が手計算と一致 | `worker/07` |
+| (d) 全ユニットテスト緑、`pyright` クリーン | 全タスク横断 |

--- a/tests/unit/test_phase1_plan_documents.py
+++ b/tests/unit/test_phase1_plan_documents.py
@@ -2,22 +2,34 @@
 
 このテストは、Phase1 タスク分解プランファイル群
 (``docs/plans/02-*.md`` 〜 ``docs/plans/09-*.md``) と、それらを俯瞰する
-インデックスファイル (``docs/plans/10-*.md``) が、指示書および計画レポートで
-定めた以下の契約を満たすことを構造的に検証する。
+**インデックスファイル** (``docs/plans/10-*.md``)、および各 Phase の
+**サービス別タスク振り分け文書** (``docs/plans/11-*.md`` /
+``docs/plans/12-*.md`` / ``docs/plans/13-*.md``) が、指示書および
+計画レポートで定めた契約を満たすことを構造的に検証する。
+
+「俯瞰インデックス」と「サービス別タスク振り分け」は別概念として明示的に
+区別する立場を取る。両者を同一の glob (``1[0-9]-*.md``) で同一視すると、
+振り分け文書の追加で俯瞰インデックスの一意性が崩れる脆弱なテストになるため、
+俯瞰インデックスは ``10-*.md`` のみで識別する。サービス別振り分け文書
+(11/12/13) は Phase 番号別に別個のファイル名規約 (``NN-phaseN-service-
+assignments.md``) を持ち、本文構造の検証は最低限の「存在性」と「Phase
+連番との整合」に限定する（過度に厳密化して将来の節構成変更を縛らない）。
 
 検証対象（指示書「成果物」と計画レポート §2.1 タスク要素一覧）:
 
 1. 02〜09 の連番でタスクプランファイル 8 本が漏れなく存在する
-2. インデックスファイルが 10 番台で 1 本だけ存在する
+2. **俯瞰**インデックスファイルが ``10-*.md`` で 1 本だけ存在する
 3. 各プランファイルが必須 10 セクションを含む
    - タスク概要 / 目的・背景 / スコープ / 依存タスク / 後続タスク /
      対象ファイル/モジュール / 実装方針 / 受入条件 / テスト計画 /
      想定 issue タイトル・ブランチ名
 4. 各プランファイルが原典 ``01-development-plan.md`` §6 のブランチ名を
    本文に保持する（タスク識別の正本との不整合を即時検出するため）
-5. インデックスファイルが Phase1 全体ゴール / タスク一覧表 /
+5. 俯瞰インデックスが Phase1 全体ゴール / タスク一覧表 /
    実装順序 / 依存関係図 の必須要素を含み、8 つのプランファイル名を
    いずれも参照している
+6. サービス別タスク振り分け文書が Phase 1/2/3 ごとに 1 本ずつ存在し、
+   frontmatter で対応 Phase 番号を宣言している
 
 設計準拠:
 - 指示書「タスク指示書: Phase1 のタスク分解と実装プラン作成」
@@ -73,6 +85,16 @@ INDEX_REQUIRED_SECTIONS: list[tuple[str, list[tuple[str, ...]]]] = [
     ("依存関係図", [("依存関係",)]),
 ]
 
+# サービス別タスク振り分け文書の連番プレフィックスと、対応する Phase 番号。
+# (number_prefix, phase) で「``NN-phaseN-service-assignments.md`` が一意に
+# 存在し、frontmatter ``phase: N`` を保持する」契約を表現する。Phase 別の
+# 内部節構成は Planner の裁量に委ね、本テストでは検証しない。
+SERVICE_ASSIGNMENTS_SPEC: list[tuple[str, int]] = [
+    ("11", 1),
+    ("12", 2),
+    ("13", 3),
+]
+
 
 @pytest.fixture
 def plans_dir(repo_root: Path) -> Path:
@@ -112,9 +134,7 @@ def _has_section(content: str, alternatives: list[tuple[str, ...]]) -> bool:
 
 def test_docs_plansディレクトリが存在する(plans_dir: Path) -> None:
     """前提条件: 出力先ディレクトリ ``docs/plans/`` が存在すること。"""
-    assert plans_dir.is_dir(), (
-        f"Phase1 プラン出力先ディレクトリが存在しません: {plans_dir}"
-    )
+    assert plans_dir.is_dir(), f"Phase1 プラン出力先ディレクトリが存在しません: {plans_dir}"
 
 
 def test_phase1のタスクプランが02から09の連番で8本そろう(plans_dir: Path) -> None:
@@ -135,15 +155,18 @@ def test_phase1のタスクプランが02から09の連番で8本そろう(plans
     )
 
 
-def test_phase1インデックスファイルが10番台で1本のみ存在する(plans_dir: Path) -> None:
+def test_phase1俯瞰インデックスファイルが10番のみで1本だけ存在する(
+    plans_dir: Path,
+) -> None:
     """指示書「タスクプランの最終番号の次の番号」の契約を検証する。
 
-    インデックスファイルは Phase1 を俯瞰する唯一の入口になるため、
-    複数本生成されると到達経路が分散して指示書の意図に反する。
+    俯瞰インデックスは Phase1 を俯瞰する唯一の入口になるため、複数本生成
+    されると到達経路が分散して指示書の意図に反する。サービス別タスク振り分け
+    文書 (11/12/13) は別概念であり、本テストの一意性条件には含めない。
     """
-    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+    index_files = sorted(plans_dir.glob("10-*.md"))
     assert len(index_files) == 1, (
-        f"Phase1 インデックスファイルは 10 番台で 1 本のみ想定。\n"
+        f"Phase1 俯瞰インデックスファイルは 10-*.md で 1 本のみ想定。\n"
         f"  発見数: {len(index_files)}\n"
         f"  発見ファイル: {[p.name for p in index_files]}"
     )
@@ -200,17 +223,19 @@ def test_各プランファイルが必須10セクションを含む(
         if not _has_section(content, alternatives):
             missing.append(section_label)
 
-    assert not missing, (
-        f"{plan_file.name} に必須セクションが見出しとして存在しません: {missing}"
-    )
+    assert not missing, f"{plan_file.name} に必須セクションが見出しとして存在しません: {missing}"
 
 
-def test_インデックスファイルが必須セクションを含む(plans_dir: Path) -> None:
-    """指示書「インデックスファイルに含める内容」を網羅検証する。"""
-    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+def test_俯瞰インデックスファイルが必須セクションを含む(plans_dir: Path) -> None:
+    """指示書「インデックスファイルに含める内容」を網羅検証する。
+
+    対象は 10-*.md の俯瞰インデックスのみ。サービス別タスク振り分け文書
+    (11/12/13) は内部節構成を Planner 裁量とするため、本テストでは
+    必須セクション検証の対象外とする。
+    """
+    index_files = sorted(plans_dir.glob("10-*.md"))
     assert len(index_files) == 1, (
-        f"インデックスファイルが一意に特定できません: "
-        f"{[p.name for p in index_files]}"
+        f"俯瞰インデックスファイルが一意に特定できません: {[p.name for p in index_files]}"
     )
     index_file = index_files[0]
     content = index_file.read_text(encoding="utf-8")
@@ -220,24 +245,23 @@ def test_インデックスファイルが必須セクションを含む(plans_d
         if not _has_section(content, alternatives):
             missing.append(section_label)
 
-    assert not missing, (
-        f"{index_file.name} に必須セクションが見出しとして存在しません: {missing}"
-    )
+    assert not missing, f"{index_file.name} に必須セクションが見出しとして存在しません: {missing}"
 
 
-def test_インデックスファイルが8つのプランファイルすべてを参照する(
+def test_俯瞰インデックスファイルが8つのプランファイルすべてを参照する(
     plans_dir: Path,
 ) -> None:
-    """インデックスから各プランへの到達経路（Markdown リンク）を検証する。
+    """俯瞰インデックスから各プランへの到達経路（Markdown リンク）を検証する。
 
     指示書「全タスクの一覧、依存関係、実装順序を俯瞰できる構成」かつ
     「依存関係はプランファイル名で参照」の契約に基づき、すべての連番プラン
-    ファイル名がインデックス本文に登場することを必須とする。
+    ファイル名が俯瞰インデックス本文に登場することを必須とする。サービス別
+    タスク振り分け文書 (11/12/13) はサブディレクトリへのディスパッチが主
+    責務であり、原典プラン全 8 本の網羅参照は要求しない（責務分離）。
     """
-    index_files = sorted(plans_dir.glob("1[0-9]-*.md"))
+    index_files = sorted(plans_dir.glob("10-*.md"))
     assert len(index_files) == 1, (
-        f"インデックスファイルが一意に特定できません: "
-        f"{[p.name for p in index_files]}"
+        f"俯瞰インデックスファイルが一意に特定できません: {[p.name for p in index_files]}"
     )
     index_content = index_files[0].read_text(encoding="utf-8")
 
@@ -293,16 +317,60 @@ def test_各プランファイルの依存タスク参照がプランファイ�
             section_body.append(line)
 
     body_text = "\n".join(section_body).strip()
-    assert body_text, (
-        f"{matches[0].name} に「依存タスク」セクションの本文がありません"
-    )
+    assert body_text, f"{matches[0].name} に「依存タスク」セクションの本文がありません"
 
     # 依存があれば 0X-*.md 形式で示すか、なければその旨が明示されていること。
-    has_plan_ref = any(
-        f"0{i}-" in body_text for i in range(2, 10)
-    )
+    has_plan_ref = any(f"0{i}-" in body_text for i in range(2, 10))
     declares_none = any(token in body_text for token in ("なし", "無し", "None"))
     assert has_plan_ref or declares_none, (
         f"{matches[0].name} の「依存タスク」セクションに、依存先プランファイル名 "
         f"(0X-*.md) も「なし」表明もありません。本文:\n{body_text}"
+    )
+
+
+def _extract_frontmatter(content: str) -> dict[str, str]:
+    """Markdown ファイル先頭の YAML frontmatter を素朴な ``key: value`` で
+    辞書化する。``yaml`` 依存を持ち込まずに ``phase`` 値だけ確認するため、
+    入れ子・リスト・複数行値は対象外（本テストでは登場しない）。
+    """
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    result: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        result[key.strip()] = value.strip()
+    return result
+
+
+@pytest.mark.parametrize(
+    ("number_prefix", "phase"),
+    SERVICE_ASSIGNMENTS_SPEC,
+    ids=[f"{prefix}=phase{phase}" for prefix, phase in SERVICE_ASSIGNMENTS_SPEC],
+)
+def test_サービス別タスク振り分け文書がphase別に1本ずつ存在する(
+    plans_dir: Path, number_prefix: str, phase: int
+) -> None:
+    """サービス別タスク振り分け文書 (11/12/13) が Phase 1/2/3 ごとに 1 本ずつ
+    存在し、frontmatter の ``phase`` 値が連番と整合することを検証する。
+
+    俯瞰インデックス (10-*.md) と振り分け文書 (11/12/13) を別概念として
+    扱う設計判断（モジュールdocstring 参照）に基づき、振り分け文書側にも
+    最低限の存在性検証を置く。Phase 番号と連番プレフィックスの食い違いは
+    インデックス全体の信頼を失わせるため、frontmatter で固定する。
+    """
+    matches = sorted(plans_dir.glob(f"{number_prefix}-phase{phase}-service-assignments.md"))
+    assert len(matches) == 1, (
+        f"サービス別タスク振り分け文書 {number_prefix}-phase{phase}-"
+        f"service-assignments.md が一意に存在しません。発見: "
+        f"{[p.name for p in matches]}"
+    )
+    frontmatter = _extract_frontmatter(matches[0].read_text(encoding="utf-8"))
+    assert frontmatter.get("phase") == str(phase), (
+        f"{matches[0].name} の frontmatter ``phase`` が {phase} と一致しません: "
+        f"{frontmatter.get('phase')!r}"
     )


### PR DESCRIPTION
## Summary
- これまで untracked のままだった `docs/plans/{11,12,13}-phase*-service-assignments.md` および `docs/plans/{api,postgres,ui,worker}/` 配下の実装プラン指示書群を取り込み
- 各指示書内の `docs/design/...` 参照を、先行 PR #6 で移動した新パス（`postgres/docs/design/...` / `worker/docs/design/...`）へ追従
- `tests/unit/test_phase1_plan_documents.py` のインデックス一意性条件を「俯瞰インデックスは 10 のみ。11/12/13 はサービス振り分けで別概念」と区別する形に再設計し、サービス振り分け文書 3 本の存在検証テストを追加

## スタック PR
- base: `feature/design-docs-per-service`（先行 PR #6）
- 先行 PR #6 が `feature/phase1-plan-docs-baseline`（PR #5）に積まれたスタックの最上段

## 設計判断
- 俯瞰インデックスとサービス別タスク振り分けは責務が異なるため、テスト側でも `10-*.md` と `1[1-3]-*.md` を別 glob で識別。サービス振り分け文書側の本文構造は Planner 裁量とし、frontmatter `phase` と連番の整合だけ固定
- 指示マップ未列挙だった `docs/plans/ui/Ph3/04-portfolio-view.md` / `05-rule-editor-ui.md` の design 参照も、同じデグレを残さないため追従修正に同梱

## Test plan
- [x] `uv run pytest tests/unit/test_phase1_plan_documents.py -v` 全 32 件 PASS
- [x] `uv run pytest -x --tb=short` 全 62 件 PASS
- [x] `git ls-files | xargs grep -lE "(^|[^/])docs/design/0[12368]-"` で旧パス残存ゼロ
- [x] `uv run ruff format --check .` / `uv run ruff check .` クリーン
- [x] `uv run pyright` 0 errors / 0 warnings