### PR TITLE
文書: docs/plans と docs/design を per-service レイアウト（ADR-014/015）へ追従

### DIFF
--- a/api/docs/plans/Ph2/README.md
+++ b/api/docs/plans/Ph2/README.md
@@ -39,7 +39,7 @@ Phase 3 で本サービスに本格着手するときの起点：
 
 - 原典: `docs/plans/01-development-plan.md` §4.3 Phase 3.1 Flask REST API
 - ブランチ: `feature/flask-rest-api`
-- Phase 2 で作成された `RawMail`, メールパーサ群, PayPal Adapter, Watcher が `src/kakeibo/` 配下に揃う想定なので、API は **既存ロジックを呼び出すだけ** の薄いレイヤとして実装可能になる
+- Phase 2 で作成された `RawMail`（`shared/kakeibo_shared/domain/raw_mail.py`）、メールパーサ群（`worker/src/kakeibo_worker/adapters/mail/`）、PayPal Adapter（`worker/src/kakeibo_worker/adapters/paypal.py`）、Watcher（`worker/src/kakeibo_worker/ingest/`）が揃う想定なので、API は共通ドメイン型と薄い repository 層を介して **既存ロジックを呼び出すだけ** のレイヤとして実装可能になる
 - 想定エンドポイント: `GET /api/transactions`（Phase 2 で投入された取引も返却対象）
 
 Phase 3.1 着手時に `api/docs/plans/Ph3/01-flask-rest-api.md` を新設する。

--- a/api/docs/plans/Ph3/01-flask-rest-api.md
+++ b/api/docs/plans/Ph3/01-flask-rest-api.md
@@ -132,7 +132,7 @@ git checkout -b feature/flask-rest-api
 
 ### 1. Red: テストを先に書く
 
-`tests/unit/api/conftest.py` で Flask test client + auth bypass fixture を用意。各エンドポイントに以下を記述：
+`api/tests/unit/conftest.py` で Flask test client + auth bypass fixture を用意。各エンドポイントに以下を記述：
 
 - `test_get_transactions_returns_paginated_list()`：50 件以下、`{data, meta: {total,page,limit}}` 構造
 - `test_get_transactions_filters_by_date_range()`：`?from=&to=` でフィルタ
@@ -145,13 +145,13 @@ git checkout -b feature/flask-rest-api
 - `test_settings_auth_bypass_default_is_false()`：本番安全性確認
 - `test_openapi_endpoint_returns_valid_spec()`：`paths` / `components.schemas` を含む
 
-`tests/integration/api/test_crud_e2e.py` で testcontainers + `worker/Ph1/05` の取込CLIフィクスチャを使い、`POST /api/categories` → `GET` で永続化確認。
+`api/tests/integration/test_crud_e2e.py` で testcontainers + `worker/docs/plans/Ph1/07-ingest-cli.md` の取込CLIフィクスチャを使い、`POST /api/categories` → `GET` で永続化確認。
 
-`pytest tests/unit/api/ tests/integration/api/` で全件赤を確認。
+`docker compose run --rm worker pytest api/tests/` で全件赤を確認。
 
 ### 2. Green: 最小実装で順に通す
 
-1. `pyproject.toml` に `flask-smorest`, `marshmallow` 追加 → `uv sync`
+1. `shared/pyproject.toml` の `[project.optional-dependencies].api` に `flask-smorest`, `marshmallow` 追加 → `docker compose build api worker`（uv が再ロックして両コンテナへ展開）
 2. `shared/kakeibo_shared/config.py` に `auth_bypass` 追加（既存テストを破壊しないよう既定値 `False`、`__repr__` のマスク非対象）
 3. `api/src/kakeibo_api/openapi.py` で `flask_smorest.Api` インスタンス生成
 4. `api/src/kakeibo_api/auth.py` で `before_request` ハンドラを実装（bypass フラグ読み取り）
@@ -179,15 +179,15 @@ git checkout -b feature/flask-rest-api
 - レスポンスに `transactions.raw_payload` が含まれない
 - ページネーション既定 `limit=100`、上限 `limit=1000` を超えるリクエストで 422
 - `pyright` クリーン、`ruff` 違反ゼロ
-- 既存テスト（`tests/unit/test_settings_repr.py` 等）が緑のまま
+- 既存テスト（`worker/tests/unit/test_settings_repr.py` 等）が緑のまま
 
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/api/ tests/integration/api/
-pytest tests/unit/test_settings_repr.py  # 既存破壊チェック
-ruff check .
-pyright
+docker compose run --rm worker pytest api/tests/
+docker compose run --rm worker pytest worker/tests/unit/test_settings_repr.py  # 既存破壊チェック
+docker compose run --rm worker ruff check api/ shared/
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約

--- a/api/docs/plans/Ph3/02-aggregation-endpoints.md
+++ b/api/docs/plans/Ph3/02-aggregation-endpoints.md
@@ -49,8 +49,8 @@ last_updated: 2026-05-01
 | `api/src/kakeibo_api/blueprints/aggregations.py` | `GET /api/balances/monthly`, `GET /api/categories/spending`, `GET /api/holdings/composition` |
 | `shared/kakeibo_shared/db/repositories/aggregations.py` | 上記 SQL を psycopg で呼ぶ薄いラッパ |
 | `api/src/kakeibo_api/app.py` | aggregations Blueprint を登録（既存ファクトリへ追記） |
-| `tests/integration/api/test_aggregations.py` | testcontainers + 決定的フィクスチャで集計値の正当性検証 |
-| `tests/unit/api/test_aggregations_validation.py` | クエリパラメータバリデーション |
+| `api/tests/integration/test_aggregations.py` | testcontainers + 決定的フィクスチャで集計値の正当性検証 |
+| `api/tests/unit/test_aggregations_validation.py` | クエリパラメータバリデーション |
 
 ## 実装方針
 
@@ -136,8 +136,8 @@ ORDER BY month;
 
 ### 1. Red
 
-- `tests/unit/api/test_aggregations_validation.py` でクエリパラメータバリデーション
-- `tests/integration/api/test_aggregations.py` で testcontainers + フィクスチャ：
+- `api/tests/unit/test_aggregations_validation.py` でクエリパラメータバリデーション
+- `api/tests/integration/test_aggregations.py` で testcontainers + フィクスチャ：
   - `test_monthly_balance_trend_returns_12_months_by_default()`
   - `test_monthly_balance_trend_with_custom_range()`
   - `test_category_spending_drilldown_includes_subcategories()`
@@ -159,7 +159,7 @@ ORDER BY month;
 ### 3. Refactor
 
 - 期間パラメータの解釈ロジックを `_parse_date_range(from_str, to_str, default_months=12)` に抽出
-- SQL ファイル読込ヘルパは Phase 1.8 の `src/kakeibo/sql/runner.py` を再利用
+- SQL ファイル読込ヘルパは Phase 1.8 で `shared/kakeibo_shared/sql/runner.py` に配置済の `run_query()` を再利用
 
 ## 受入条件
 
@@ -173,9 +173,9 @@ ORDER BY month;
 ## 品質ゲート
 
 ```bash
-pytest tests/integration/api/test_aggregations.py tests/unit/api/test_aggregations_validation.py
-ruff check .
-pyright
+docker compose run --rm worker pytest api/tests/integration/test_aggregations.py api/tests/unit/test_aggregations_validation.py
+docker compose run --rm worker ruff check api/ shared/ postgres/
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -199,8 +199,8 @@ Phase 3.3〜3.5 集計エンドポイントを実装。
 - api/src/kakeibo_api/blueprints/aggregations.py
 - api/src/kakeibo_api/schemas/aggregations.py
 - shared/kakeibo_shared/db/repositories/aggregations.py
-- tests/integration/api/test_aggregations.py
-- tests/unit/api/test_aggregations_validation.py
+- api/tests/integration/test_aggregations.py
+- api/tests/unit/test_aggregations_validation.py
 
 ## 検証結果
 - pytest 全件緑

--- a/api/docs/plans/Ph3/03-rule-dry-run-endpoint.md
+++ b/api/docs/plans/Ph3/03-rule-dry-run-endpoint.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 ## 担当サービス
 
-`compose.yml` `api` サービス。`api/Ph3/01` のルール CRUD を拡張する形で dry-run を追加し、`design/03-categorization-engine.md` の Rule マッチロジックを `src/kakeibo/categorizer/` 配下に実装ファイル化する。
+`compose.yml` `api` サービス。`api/Ph3/01` のルール CRUD を拡張する形で dry-run を追加し、`design/03-categorization-engine.md` の Rule マッチロジックを `api/src/kakeibo_api/categorizer/` 配下に実装ファイル化する。
 
 ## 上流・下流
 
@@ -42,16 +42,16 @@ last_updated: 2026-05-01
 
 | パス | 役割 |
 |---|---|
-| `src/kakeibo/categorizer/__init__.py` | 新規パッケージ |
-| `src/kakeibo/categorizer/rules.py` | `match_rule(rule, transaction) -> bool` の実装 |
-| `src/kakeibo/categorizer/safe_regex.py` | regex タイムアウト保護 |
+| `api/src/kakeibo_api/categorizer/__init__.py` | 新規パッケージ |
+| `api/src/kakeibo_api/categorizer/rules.py` | `match_rule(rule, transaction) -> bool` の実装 |
+| `api/src/kakeibo_api/categorizer/safe_regex.py` | regex タイムアウト保護 |
 | `api/src/kakeibo_api/blueprints/rules.py` | 既存に `POST /api/rules/dry-run` を追加 |
 | `api/src/kakeibo_api/schemas/rule.py` | `DryRunRequest`, `DryRunResponse` を追加（既存に追記） |
 | `shared/kakeibo_shared/db/repositories/rules.py` | 既存に `match_transactions(...)` を追加 |
-| `tests/unit/categorizer/__init__.py` | 新規 |
-| `tests/unit/categorizer/test_rules.py` | match_type 別の単体テスト（regex / contains / exact） |
-| `tests/unit/categorizer/test_safe_regex.py` | ReDoS パターンでのタイムアウト検証 |
-| `tests/unit/api/test_rule_dry_run.py` | エンドポイント契約 + 件数算出 |
+| `api/tests/unit/categorizer/__init__.py` | 新規 |
+| `api/tests/unit/categorizer/test_rules.py` | match_type 別の単体テスト（regex / contains / exact） |
+| `api/tests/unit/categorizer/test_safe_regex.py` | ReDoS パターンでのタイムアウト検証 |
+| `api/tests/unit/test_rule_dry_run.py` | エンドポイント契約 + 件数算出 |
 
 ## 実装方針
 
@@ -103,16 +103,16 @@ Content-Type: application/json
 
 ### 1. Red
 
-- `tests/unit/categorizer/test_safe_regex.py`：
+- `api/tests/unit/categorizer/test_safe_regex.py`：
   - `test_safe_regex_match_normal_pattern_succeeds()`
   - `test_safe_regex_redos_pattern_times_out()`：`(a+)+$` + 30 文字超の `a` 列で `TimeoutError`、テスト全体は 1 秒以内に完了
   - `test_safe_regex_pattern_length_exceeded()`：500 文字超で `ValueError`
-- `tests/unit/categorizer/test_rules.py`：
+- `api/tests/unit/categorizer/test_rules.py`：
   - `test_match_type_regex_matches_pattern()`
   - `test_match_type_contains_substring()`
   - `test_match_type_exact_full_match()`
   - `test_match_type_invalid_raises_value_error()`
-- `tests/unit/api/test_rule_dry_run.py`：
+- `api/tests/unit/test_rule_dry_run.py`：
   - `test_dry_run_returns_zero_for_no_match_pattern()`
   - `test_dry_run_returns_sample_with_at_most_10_transactions()`
   - `test_dry_run_rejects_invalid_match_type()`（422）
@@ -123,7 +123,7 @@ Content-Type: application/json
 
 ### 2. Green
 
-1. `src/kakeibo/categorizer/safe_regex.py` を実装：
+1. `api/src/kakeibo_api/categorizer/safe_regex.py` を実装：
    ```python
    def safe_regex_match(pattern: str, text: str, *, timeout_ms: int = 500) -> bool:
        if len(pattern) > 500:
@@ -137,7 +137,7 @@ Content-Type: application/json
        finally:
            signal.setitimer(signal.ITIMER_REAL, 0)
    ```
-2. `src/kakeibo/categorizer/rules.py` で `match_rule(rule, transaction) -> bool` を実装
+2. `api/src/kakeibo_api/categorizer/rules.py` で `match_rule(rule, transaction) -> bool` を実装
 3. `shared/kakeibo_shared/db/repositories/rules.py` に `match_transactions(conn, *, match_field, match_type, pattern, limit=10)` を追加
 4. `api/src/kakeibo_api/schemas/rule.py` に `DryRunRequest`, `DryRunResponse` を追加
 5. `api/src/kakeibo_api/blueprints/rules.py` に `POST /api/rules/dry-run` を追加
@@ -165,9 +165,9 @@ Content-Type: application/json
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/categorizer/ tests/unit/api/test_rule_dry_run.py
-ruff check .
-pyright
+docker compose run --rm worker pytest api/tests/unit/categorizer/ api/tests/unit/test_rule_dry_run.py
+docker compose run --rm worker ruff check api/ shared/
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -186,11 +186,11 @@ pyright
 Phase 3.6 ルール dry-run エンドポイントとCategorizerコアを実装。
 
 ## 成果物
-- src/kakeibo/categorizer/{rules,safe_regex}.py
+- api/src/kakeibo_api/categorizer/{__init__,rules,safe_regex}.py
 - api/src/kakeibo_api/blueprints/rules.py（dry-run 追加）
 - api/src/kakeibo_api/schemas/rule.py（DryRunRequest/Response 追加）
 - shared/kakeibo_shared/db/repositories/rules.py（match_transactions 追加）
-- tests/unit/categorizer/* / tests/unit/api/test_rule_dry_run.py
+- api/tests/unit/categorizer/* / api/tests/unit/test_rule_dry_run.py
 
 ## 検証結果
 - pytest 全件緑（< 1 秒で完了、ReDoS テスト含む）

--- a/api/docs/plans/Ph3/README.md
+++ b/api/docs/plans/Ph3/README.md
@@ -22,9 +22,9 @@ last_updated: 2026-05-01
 | 共通エラーハンドラ | `api/src/kakeibo_api/errors.py` |
 | OpenAPI 自動生成 | `api/src/kakeibo_api/openapi.py` |
 | リポジトリ層（psycopg ベース、ORM 不採用） | `shared/kakeibo_shared/db/repositories/` |
-| Categorizer（dry-run 用ロジック） | `src/kakeibo/categorizer/` |
-| 集計 SQL（Phase 1.8 に追加） | `postgres/src/sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql` |
-| API 関連テスト | `tests/unit/api/`, `tests/integration/api/`, `tests/unit/categorizer/` |
+| Categorizer（dry-run 用ロジック、Phase 4.x で worker 側ジョブから再利用） | `api/src/kakeibo_api/categorizer/` |
+| 集計 SQL（Phase 3 で追加、Phase 1.8 の `monthly_summary.sql` と並置） | `postgres/src/sql/queries/{monthly_balance_trend,category_spending,portfolio_composition}.sql` |
+| API 関連テスト | `api/tests/unit/`, `api/tests/integration/`, `api/tests/unit/categorizer/` |
 
 ### このディレクトリでは扱わないもの
 
@@ -80,9 +80,9 @@ api/Ph3/01 (REST API 基盤)
 ## 共通の品質ゲート
 
 ```bash
-pytest tests/unit/api/ tests/integration/api/ tests/unit/categorizer/
-ruff check .
-pyright
+docker compose run --rm worker pytest api/tests/
+docker compose run --rm worker ruff check api/ shared/
+docker compose run --rm worker pyright
 ```
 
 統合確認（`api/Ph3/01〜03` 全完了後）：

--- a/api/docs/plans/README.md
+++ b/api/docs/plans/README.md
@@ -23,9 +23,9 @@ Phase 1 のタスク（1.1〜1.8）はすべて `postgres` または `worker` �
 | エントリポイント | `api/src/kakeibo_api/__main__.py` |
 | Phase3 で REST 拡張する Blueprint | （未配置）`api/src/kakeibo_api/blueprints/` 想定 |
 | api コンテナ Dockerfile | `api/Dockerfile`（uv マルチステージ） |
-| api コンテナ wrapper | `api/kakeibo_api/__init__.py`（`create_app` 再エクスポートのみ） |
+| api 公開 API（`create_app` 再エクスポート） | `api/src/kakeibo_api/__init__.py` |
 
-`api` コンテナの Dockerfile は `src/kakeibo` 全体を COPY するため、`worker/01〜07` で実装した共通ライブラリ（domain / adapters / ingest / sql）も同じ image に含まれる。Phase 3.1 で REST API を実装する際はこれを再利用する。
+`api` Dockerfile は `api/src/kakeibo_api/` と `shared/kakeibo_shared/` を COPY し、`shared/pyproject.toml` の `[project.optional-dependencies].api` を `uv sync --extra api` で導入する（ADR-014 / ADR-015）。共通ライブラリ（`shared/kakeibo_shared/{config,logging,db,domain}/`）は両コンテナに配備されるため、Phase 3.1 で REST API を実装する際は worker 側で実装したリポジトリ/ドメイン型を再利用する。
 
 ## Phase1 の間に api サービスへ波及する変更（許容例）
 

--- a/docs/design/00-overview.md
+++ b/docs/design/00-overview.md
@@ -15,10 +15,10 @@ related_adrs: []
 
 | コンポーネント | 役割 | コードルート |
 |---|---|---|
-| postgres | データの正本（取引・残高・ルール・カテゴリ） | `postgres/`（Phase 1 で新設） |
+| postgres | データの正本（取引・残高・ルール・カテゴリ） | `postgres/`（Phase 0 で配備済。マイグレーション本体は Phase 1.1 で着手） |
 | worker | 取込・分類・連動取引・出力連携バッチ | `worker/` |
 | api | 集計エンドポイント（Flask、Phase 3） | `api/` |
-| ui | ダッシュボード（Next.js、Phase 4） | `ui/` |
+| ui | ダッシュボード（Next.js、Phase 3.2） | `ui/` |
 | caddy | リバースプロキシ・Tailscale 認証 | （ルート設定のみ） |
 | backup | dump/restic | （ルート設定のみ） |
 

--- a/docs/design/04-deployment-stack.md
+++ b/docs/design/04-deployment-stack.md
@@ -17,10 +17,10 @@ related_adrs:
 
 設計原則: ADR-009（NAS + Docker Compose採用）、ADR-010（Tailscale限定アクセス）、ADR-012（バックアップ3階層）。
 
-## 2. docker-compose.yml
+## 2. compose.yml
 
 ```yaml
-# /volume1/docker/kakeibo/docker-compose.yml
+# /volume1/docker/kakeibo/compose.yml
 services:
   postgres:
     image: postgres:16-alpine
@@ -333,7 +333,7 @@ docker compose up -d --no-deps api worker ui
 #    pg_dumpall → 新コンテナで pg_restore
 ```
 
-DBスキーマ変更時は Alembic で migration を実行（`docker compose run --rm worker alembic upgrade head`）。
+DBスキーマ変更時は Alembic で migration を実行（`docker compose run --rm worker alembic -c postgres/src/alembic.ini upgrade head`）。`alembic.ini` は ADR-014 に従い `postgres/src/` 配下に配置されている。
 
 ## 11. 起動・停止
 

--- a/docs/plans/00-initial-design.md
+++ b/docs/plans/00-initial-design.md
@@ -440,7 +440,7 @@ flowchart LR
 ### 7.1 Docker Composeスタック
 
 ```yaml
-# /volume1/docker/kakeibo/docker-compose.yml
+# /volume1/docker/kakeibo/compose.yml
 services:
   postgres:
     image: postgres:16-alpine

--- a/docs/plans/01-development-plan.md
+++ b/docs/plans/01-development-plan.md
@@ -174,7 +174,7 @@ parent: docs/plans/00-initial-design.md
 
 | 項目 | 内容 |
 |---|---|
-| 目的 | `python -m kakeibo.ingest <institution> <path>` 相当のコマンドを提供し、アダプタ起動 → DB 永続化 → 原本退避までを一気通貫で実行する |
+| 目的 | `python -m kakeibo_worker.ingest <institution> <path>` 相当のコマンドを提供し、アダプタ起動 → DB 永続化 → 原本退避までを一気通貫で実行する |
 | 関連 ADR | ADR-006（hash 冪等性）, ADR-007 |
 | 関連 design | design/02-ingest-adapters, design/08-ingest-flow |
 | ブランチ | `feature/ingest-cli` |
@@ -198,7 +198,7 @@ parent: docs/plans/00-initial-design.md
 
 | 項目 | 内容 |
 |---|---|
-| 目的 | Phase 1 完了基準である「SQL で月次サマリが手計算と一致」を満たす集計クエリを `postgres/src/sql/queries/monthly_summary.sql` として配置する |
+| 目的 | Phase 1 完了基準である「SQL で月次サマリが手計算と一致」を満たす集計クエリを `postgres/src/sql/queries/monthly_summary.sql` として配置し、SQL ファイル読込ヘルパを `shared/kakeibo_shared/sql/runner.py` に置く |
 | 関連 ADR | ADR-004 |
 | 関連 design | design/01-data-model |
 | ブランチ | `feature/monthly-summary-sql` |
@@ -568,18 +568,19 @@ flowchart TD
 
 ### 8.1 ツール要件
 
-| ツール | バージョン | 用途 |
-|---|---|---|
-| Python | 3.12 以上 | バックエンド / Worker / CLI |
-| PostgreSQL | 16 | DB（ADR-004） |
-| Docker / Docker Compose | 24+ / v2 | ローカル / NAS デプロイ（ADR-009） |
-| Node.js | 20 LTS | UI（Phase 3 以降） |
-| pnpm or npm | 最新安定版 | UI パッケージ管理 |
-| Alembic | 1.13+ | マイグレーション |
-| pytest | 8+ | テストランナー |
-| pyright | 最新 | 型チェック |
-| ruff | 最新 | lint / formatter |
-| Playwright | 最新 | e2e（Phase 3 以降） |
+ADR-015 により Python ツールチェーンはすべてコンテナ内で完結する。下記「ホスト要件」は最小、コンテナ内バージョンは `shared/pyproject.toml` / `ui/package.json` / `*/Dockerfile` で固定。
+
+| ツール | バージョン | 用途 | 配置 |
+|---|---|---|---|
+| Docker / Docker Compose | 24+ / v2 | 唯一のホスト要件（ADR-009 / 015） | ホスト |
+| Python | 3.12 以上 | api / worker コンテナのランタイム | api / worker コンテナ |
+| PostgreSQL | 16 | DB（ADR-004） | postgres コンテナ |
+| Node.js | 20 LTS | UI ビルド・実行 | ui コンテナ |
+| Alembic | 1.13+ | マイグレーション（worker extras 経由） | worker コンテナ内 |
+| pytest / hypothesis / testcontainers | 最新 | テストランナー（dev extras） | worker コンテナ内 |
+| pyright | 1.1.360+ | 型チェック（dev extras） | worker コンテナ内 |
+| ruff | 0.5+ | lint / formatter（dev extras） | worker コンテナ内 |
+| Playwright | 最新 | e2e（Phase 3 以降） | ui コンテナ内 |
 
 ### 8.2 外部サービス・認証情報
 
@@ -594,25 +595,30 @@ flowchart TD
 
 ### 8.3 ローカル開発初期化手順
 
+ADR-015 によりホストには Docker のみを要求し、Python ツールチェーン（uv / pytest / ruff / pyright / alembic）はすべて `worker` コンテナ内で実行する。`shared/pyproject.toml` が共通の依存マニフェストで、`shared/uv.lock` がロックされている。
+
 ```bash
 # 1. リポジトリ取得後
 git checkout develop && git pull origin develop
 
-# 2. Python 仮想環境
-python3.12 -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
+# 2. secrets を配置（.example をコピーして実値を入れる）
+cp secrets/pg_password.txt.example secrets/pg_password.txt   # 等
 
-# 3. Postgres 起動（Docker Compose）
-docker compose -f docker-compose.dev.yml up -d postgres
+# 3. Postgres / api / worker / ui / caddy をビルド & 起動
+docker compose up -d --build
 
-# 4. マイグレーション
-alembic upgrade head
+# 4. マイグレーション（worker コンテナ内で alembic 実行）
+docker compose run --rm worker alembic -c postgres/src/alembic.ini upgrade head
 
-# 5. テスト実行
-pytest
+# 5. テスト実行（worker コンテナ内で pytest 実行、横断は ./tests、サービス専有は <service>/tests/）
+docker compose run --rm worker pytest tests/ worker/tests/ api/tests/
+
+# 6. lint / typecheck（同様にコンテナ内で実行）
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
-UI 関連は Phase 3.2 以降で `ui/` ディレクトリに `pnpm install` を追加する。
+UI 関連の Node 依存は `ui/Dockerfile` のビルド時に `npm ci` で導入される。Phase 3.2 以降の開発では `docker compose run --rm ui npm run dev` 等を利用する（ホストに Node を入れる必要はない）。
 
 ---
 

--- a/docs/plans/12-phase2-service-assignments.md
+++ b/docs/plans/12-phase2-service-assignments.md
@@ -41,25 +41,32 @@ Phase2 は **すべて `worker` サービスに集約** される。Phase1 で�
 
 ## 3. サブディレクトリ構成
 
+ADR-014（per-service source layout）により Phase2 タスク指示書も `<service>/docs/plans/Ph2/` に同梱する。
+
 ```
-docs/plans/
-├── 12-phase2-service-assignments.md  # 本ファイル（Phase2 振り分け）
-├── postgres/Ph2/
-│   └── README.md                      # 担当タスクなし
-├── worker/Ph2/
-│   ├── README.md                      # worker サービス Phase2 一覧
-│   ├── 01-watcher-service.md          # Phase 2.1
-│   ├── 02-archive-and-dead-letter.md  # Phase 2.2
-│   ├── 03-gmail-mcp-client.md         # Phase 2.3
-│   ├── 04-parser-amazon-mail.md       # Phase 2.4
-│   ├── 05-parser-rakuten-mail.md      # Phase 2.5
-│   ├── 06-parser-yahoo-mail.md        # Phase 2.6
-│   ├── 07-adapter-paypal-api.md       # Phase 2.7
-│   └── 08-cron-batch-runner.md        # Phase 2.8
-├── api/Ph2/
-│   └── README.md                      # 担当タスクなし
-└── ui/Ph2/
-    └── README.md                      # 担当タスクなし
+.
+├── docs/plans/
+│   └── 12-phase2-service-assignments.md  # 本ファイル（Phase2 振り分け）
+│
+├── postgres/docs/plans/Ph2/
+│   └── README.md                          # 担当タスクなし
+│
+├── worker/docs/plans/Ph2/
+│   ├── README.md                          # worker サービス Phase2 一覧
+│   ├── 01-watcher-service.md              # Phase 2.1
+│   ├── 02-archive-and-dead-letter.md      # Phase 2.2
+│   ├── 03-gmail-mcp-client.md             # Phase 2.3
+│   ├── 04-parser-amazon-mail.md           # Phase 2.4
+│   ├── 05-parser-rakuten-mail.md          # Phase 2.5
+│   ├── 06-parser-yahoo-mail.md            # Phase 2.6
+│   ├── 07-adapter-paypal-api.md           # Phase 2.7
+│   └── 08-cron-batch-runner.md            # Phase 2.8
+│
+├── api/docs/plans/Ph2/
+│   └── README.md                          # 担当タスクなし
+│
+└── ui/docs/plans/Ph2/
+    └── README.md                          # 担当タスクなし
 ```
 
 Phase2 の **原典は `docs/plans/01-development-plan.md` §4.2** のみ（Phase1 のような独立詳細プランファイル `12-phase2-*.md` は **作らない方針**：原典が必要十分に簡潔で、サービス別指示書だけで Coder が着手できるため）。原典との乖離時は原典優先。
@@ -96,14 +103,14 @@ Phase2 の **原典は `docs/plans/01-development-plan.md` §4.2** のみ（Phas
 
 | 連番 | 担当タスク | 指示書 | 原典（行範囲） | ブランチ | 優先度 |
 |---|---|---|---|---|---|
-| 01 | Phase 2.1 watchdog Watcher サービス | [`worker/Ph2/01-watcher-service.md`](./worker/Ph2/01-watcher-service.md) | §4.2 L211-221 | `feature/watcher-service` | 🔴 高 |
-| 02 | Phase 2.2 アーカイブ移動 + dead letter | [`worker/Ph2/02-archive-and-dead-letter.md`](./worker/Ph2/02-archive-and-dead-letter.md) | §4.2 L223-233 | `feature/archive-and-dead-letter` | 🟠 中 |
-| 03 | Phase 2.3 Gmail MCP 接続 | [`worker/Ph2/03-gmail-mcp-client.md`](./worker/Ph2/03-gmail-mcp-client.md) | §4.2 L235-245 | `feature/gmail-mcp-client` | 🔴 高 |
-| 04 | Phase 2.4 Amazon メールパーサ | [`worker/Ph2/04-parser-amazon-mail.md`](./worker/Ph2/04-parser-amazon-mail.md) | §4.2 L247-257 | `feature/parser-amazon-mail` | 🟡 中 |
-| 05 | Phase 2.5 楽天市場 メールパーサ | [`worker/Ph2/05-parser-rakuten-mail.md`](./worker/Ph2/05-parser-rakuten-mail.md) | §4.2 L259-269 | `feature/parser-rakuten-mail` | 🟡 中 |
-| 06 | Phase 2.6 Yahoo!ショッピング メールパーサ | [`worker/Ph2/06-parser-yahoo-mail.md`](./worker/Ph2/06-parser-yahoo-mail.md) | §4.2 L271-281 | `feature/parser-yahoo-mail` | 🟡 中 |
-| 07 | Phase 2.7 PayPal API クライアント | [`worker/Ph2/07-adapter-paypal-api.md`](./worker/Ph2/07-adapter-paypal-api.md) | §4.2 L283-293 | `feature/adapter-paypal-api` | 🔴 高 |
-| 08 | Phase 2.8 cron バッチ運用化 | [`worker/Ph2/08-cron-batch-runner.md`](./worker/Ph2/08-cron-batch-runner.md) | §4.2 L295-305 | `feature/cron-batch-runner` | 🟠 中 |
+| 01 | Phase 2.1 watchdog Watcher サービス | [`worker/Ph2/01-watcher-service.md`](../../worker/docs/plans/Ph2/01-watcher-service.md) | §4.2 L211-221 | `feature/watcher-service` | 🔴 高 |
+| 02 | Phase 2.2 アーカイブ移動 + dead letter | [`worker/Ph2/02-archive-and-dead-letter.md`](../../worker/docs/plans/Ph2/02-archive-and-dead-letter.md) | §4.2 L223-233 | `feature/archive-and-dead-letter` | 🟠 中 |
+| 03 | Phase 2.3 Gmail MCP 接続 | [`worker/Ph2/03-gmail-mcp-client.md`](../../worker/docs/plans/Ph2/03-gmail-mcp-client.md) | §4.2 L235-245 | `feature/gmail-mcp-client` | 🔴 高 |
+| 04 | Phase 2.4 Amazon メールパーサ | [`worker/Ph2/04-parser-amazon-mail.md`](../../worker/docs/plans/Ph2/04-parser-amazon-mail.md) | §4.2 L247-257 | `feature/parser-amazon-mail` | 🟡 中 |
+| 05 | Phase 2.5 楽天市場 メールパーサ | [`worker/Ph2/05-parser-rakuten-mail.md`](../../worker/docs/plans/Ph2/05-parser-rakuten-mail.md) | §4.2 L259-269 | `feature/parser-rakuten-mail` | 🟡 中 |
+| 06 | Phase 2.6 Yahoo!ショッピング メールパーサ | [`worker/Ph2/06-parser-yahoo-mail.md`](../../worker/docs/plans/Ph2/06-parser-yahoo-mail.md) | §4.2 L271-281 | `feature/parser-yahoo-mail` | 🟡 中 |
+| 07 | Phase 2.7 PayPal API クライアント | [`worker/Ph2/07-adapter-paypal-api.md`](../../worker/docs/plans/Ph2/07-adapter-paypal-api.md) | §4.2 L283-293 | `feature/adapter-paypal-api` | 🔴 高 |
+| 08 | Phase 2.8 cron バッチ運用化 | [`worker/Ph2/08-cron-batch-runner.md`](../../worker/docs/plans/Ph2/08-cron-batch-runner.md) | §4.2 L295-305 | `feature/cron-batch-runner` | 🟠 中 |
 
 ## 6. 依存関係図
 
@@ -160,7 +167,7 @@ worker/Ph2/07 (PayPal API)
 
 | 項目 | 内容 |
 |---|---|
-| Phase1 完了 | `worker/Ph1/05` (取込CLI) と `postgres/Ph1/01` (スキーマ) が緑であること |
+| Phase1 完了 | `worker/Ph1/07` (取込CLI) と `postgres/Ph1/02` (スキーマ) が緑であること |
 | Docker secret | `secrets/{gmail_oauth_token.json, paypal_api_secret.txt}` が運用環境に配置済（開発時は `.example` ベース） |
 | 環境変数 | `INBOX_PATH=/inbox`, `ARCHIVE_PATH=/archive`, `DEAD_LETTER_PATH=/dead_letter`, `GMAIL_OAUTH_TOKEN_FILE`, `PAYPAL_API_SECRET_FILE` は `compose.yml` で宣言済み |
 | 依存パッケージ | `pyproject.toml` `[project.optional-dependencies].mail`（mail-parser, beautifulsoup4, lxml）を `--extra mail` で導入 |

--- a/docs/plans/13-phase3-service-assignments.md
+++ b/docs/plans/13-phase3-service-assignments.md
@@ -45,26 +45,33 @@ last_updated: 2026-05-01
 
 ## 3. サブディレクトリ構成
 
+ADR-014（per-service source layout）により Phase3 タスク指示書も `<service>/docs/plans/Ph3/` に同梱する。
+
 ```
-docs/plans/
-├── 13-phase3-service-assignments.md          # 本ファイル（Phase3 振り分け）
-├── postgres/Ph3/
-│   └── README.md                              # 担当タスクなし宣言
-├── api/Ph3/
-│   ├── README.md                              # api サービス Phase3 一覧
-│   ├── 01-flask-rest-api.md                   # Phase 3.1 主担当（CRUD + OpenAPI + 認証）
-│   ├── 02-aggregation-endpoints.md            # Phase 3.3〜3.5 補助（集計 API）
-│   └── 03-rule-dry-run-endpoint.md            # Phase 3.6 補助（プレビュー）
-├── worker/Ph3/
-│   └── README.md                              # 担当タスクなし宣言
-└── ui/Ph3/
-    ├── README.md                              # ui サービス Phase3 一覧
-    ├── 01-react-dashboard-scaffold.md         # Phase 3.2
-    ├── 02-monthly-trend-chart.md              # Phase 3.3
-    ├── 03-category-spending-view.md           # Phase 3.4
-    ├── 04-portfolio-view.md                   # Phase 3.5
-    ├── 05-rule-editor-ui.md                   # Phase 3.6
-    └── 06-e2e-playwright.md                   # 完了条件 (d) Playwright e2e（横断）
+.
+├── docs/plans/
+│   └── 13-phase3-service-assignments.md          # 本ファイル（Phase3 振り分け）
+│
+├── postgres/docs/plans/Ph3/
+│   └── README.md                                  # 担当タスクなし宣言
+│
+├── api/docs/plans/Ph3/
+│   ├── README.md                                  # api サービス Phase3 一覧
+│   ├── 01-flask-rest-api.md                       # Phase 3.1 主担当（CRUD + OpenAPI + 認証）
+│   ├── 02-aggregation-endpoints.md                # Phase 3.3〜3.5 補助（集計 API）
+│   └── 03-rule-dry-run-endpoint.md                # Phase 3.6 補助（プレビュー）
+│
+├── worker/docs/plans/Ph3/
+│   └── README.md                                  # 担当タスクなし宣言
+│
+└── ui/docs/plans/Ph3/
+    ├── README.md                                  # ui サービス Phase3 一覧
+    ├── 01-react-dashboard-scaffold.md             # Phase 3.2
+    ├── 02-monthly-trend-chart.md                  # Phase 3.3
+    ├── 03-category-spending-view.md               # Phase 3.4
+    ├── 04-portfolio-view.md                       # Phase 3.5
+    ├── 05-rule-editor-ui.md                       # Phase 3.6
+    └── 06-e2e-playwright.md                       # 完了条件 (d) Playwright e2e（横断）
 ```
 
 Phase 3 でも **原典は `docs/plans/01-development-plan.md` §4.3 のみ**（Phase 1 のような独立詳細プランファイルは作らない方針を踏襲）。原典との乖離時は原典優先。
@@ -104,15 +111,15 @@ Phase 3 でも **原典は `docs/plans/01-development-plan.md` §4.3 のみ**（
 
 | 連番 | 担当タスク | 指示書 | 原典（行範囲） | ブランチ | 優先度 |
 |---|---|---|---|---|---|
-| api/01 | Phase 3.1 Flask REST API | [`api/Ph3/01-flask-rest-api.md`](./api/Ph3/01-flask-rest-api.md) | §4.3 L309-319 | `feature/flask-rest-api` | 🔴 高 |
-| api/02 | Phase 3.3〜3.5 集計エンドポイント | [`api/Ph3/02-aggregation-endpoints.md`](./api/Ph3/02-aggregation-endpoints.md) | §4.3 L333-365 | `feature/api-aggregation-endpoints` | 🟡 中 |
-| api/03 | Phase 3.6 ルール dry-run | [`api/Ph3/03-rule-dry-run-endpoint.md`](./api/Ph3/03-rule-dry-run-endpoint.md) | §4.3 L367-377 | `feature/api-rule-dry-run` | 🟡 中 |
-| ui/01 | Phase 3.2 React Dashboard 雛形 | [`ui/Ph3/01-react-dashboard-scaffold.md`](./ui/Ph3/01-react-dashboard-scaffold.md) | §4.3 L321-331 | `feature/react-dashboard-scaffold` | 🔴 高 |
-| ui/02 | Phase 3.3 月次推移グラフ | [`ui/Ph3/02-monthly-trend-chart.md`](./ui/Ph3/02-monthly-trend-chart.md) | §4.3 L333-343 | `feature/monthly-trend-chart` | 🟡 中 |
-| ui/03 | Phase 3.4 カテゴリ別支出ビュー | [`ui/Ph3/03-category-spending-view.md`](./ui/Ph3/03-category-spending-view.md) | §4.3 L345-355 | `feature/category-spending-view` | 🟡 中 |
-| ui/04 | Phase 3.5 ポートフォリオ構成ビュー | [`ui/Ph3/04-portfolio-view.md`](./ui/Ph3/04-portfolio-view.md) | §4.3 L357-365 | `feature/portfolio-view` | 🟡 中 |
-| ui/05 | Phase 3.6 ルール編集UI | [`ui/Ph3/05-rule-editor-ui.md`](./ui/Ph3/05-rule-editor-ui.md) | §4.3 L367-377 | `feature/rule-editor-ui` | 🔴 高 |
-| ui/06 | Phase 3 完了条件 (d) Playwright e2e | [`ui/Ph3/06-e2e-playwright.md`](./ui/Ph3/06-e2e-playwright.md) | §3.3 完了条件 (d) | `feature/playwright-e2e` | 🟡 中 |
+| api/01 | Phase 3.1 Flask REST API | [`api/Ph3/01-flask-rest-api.md`](../../api/docs/plans/Ph3/01-flask-rest-api.md) | §4.3 L309-319 | `feature/flask-rest-api` | 🔴 高 |
+| api/02 | Phase 3.3〜3.5 集計エンドポイント | [`api/Ph3/02-aggregation-endpoints.md`](../../api/docs/plans/Ph3/02-aggregation-endpoints.md) | §4.3 L333-365 | `feature/api-aggregation-endpoints` | 🟡 中 |
+| api/03 | Phase 3.6 ルール dry-run | [`api/Ph3/03-rule-dry-run-endpoint.md`](../../api/docs/plans/Ph3/03-rule-dry-run-endpoint.md) | §4.3 L367-377 | `feature/api-rule-dry-run` | 🟡 中 |
+| ui/01 | Phase 3.2 React Dashboard 雛形 | [`ui/Ph3/01-react-dashboard-scaffold.md`](../../ui/docs/plans/Ph3/01-react-dashboard-scaffold.md) | §4.3 L321-331 | `feature/react-dashboard-scaffold` | 🔴 高 |
+| ui/02 | Phase 3.3 月次推移グラフ | [`ui/Ph3/02-monthly-trend-chart.md`](../../ui/docs/plans/Ph3/02-monthly-trend-chart.md) | §4.3 L333-343 | `feature/monthly-trend-chart` | 🟡 中 |
+| ui/03 | Phase 3.4 カテゴリ別支出ビュー | [`ui/Ph3/03-category-spending-view.md`](../../ui/docs/plans/Ph3/03-category-spending-view.md) | §4.3 L345-355 | `feature/category-spending-view` | 🟡 中 |
+| ui/04 | Phase 3.5 ポートフォリオ構成ビュー | [`ui/Ph3/04-portfolio-view.md`](../../ui/docs/plans/Ph3/04-portfolio-view.md) | §4.3 L357-365 | `feature/portfolio-view` | 🟡 中 |
+| ui/05 | Phase 3.6 ルール編集UI | [`ui/Ph3/05-rule-editor-ui.md`](../../ui/docs/plans/Ph3/05-rule-editor-ui.md) | §4.3 L367-377 | `feature/rule-editor-ui` | 🔴 高 |
+| ui/06 | Phase 3 完了条件 (d) Playwright e2e | [`ui/Ph3/06-e2e-playwright.md`](../../ui/docs/plans/Ph3/06-e2e-playwright.md) | §3.3 完了条件 (d) | `feature/playwright-e2e` | 🟡 中 |
 
 ## 6. 依存関係図
 
@@ -171,7 +178,7 @@ flowchart TD
 
 | # | 判断事項 | 採用 | 理由 |
 |---|---|---|---|
-| 1 | **Vite 移行 vs Next.js 維持** | **Next.js 14 維持** | Phase 0 の Dockerfile / standalone build / healthcheck / 既存テスト保護（`agent-rules/00-core-principles.md` §1）。原典の「Vite + TypeScript + React」は本質である「TypeScript + React」を採用、ビルド基盤は Next.js を継続。差分は `ui/Ph3/01` 内で実装方針として明記。 |
+| 1 | **Vite 移行 vs Next.js 維持** | **Next.js 14 維持** | Phase 0 の Dockerfile（`ui/src/app/{layout,page}.tsx` 配置）/ standalone build / healthcheck / 既存テスト保護（`agent-rules/00-core-principles.md` §1）。原典の「Vite + TypeScript + React」は本質である「TypeScript + React」を採用、ビルド基盤は Next.js を継続。差分は `ui/Ph3/01` 内で実装方針として明記。 |
 | 2 | **状態管理** | `@tanstack/react-query` v5 | データ取得・キャッシュ・mutate の業界標準。Redux / Zustand は YAGNI。 |
 | 3 | **API クライアント型** | OpenAPI から `openapi-typescript` で機械生成 | 手書きは重複リスク。`api/Ph3/01` で `/api/openapi.json` を valid 保証。 |
 | 4 | **OpenAPI 生成（API 側）** | `flask-smorest` | pydantic v2 連携・自動 spec 生成・Swagger UI 同梱。`apispec` 単体は手書き spec 多。 |
@@ -199,11 +206,11 @@ flowchart TD
 - **リスク R-10（Tailscale Funnel）**: ADR-010 §結果で「Funnel 不使用」確定済み、Phase3 に影響なし。
 - **認証ヘッダ実機検証**は Phase 3 内では unit test レベルで完結、本番 Caddy 経路の検証は Phase 4.6 リリース時に実施。
 - **SQLAlchemy ORM 不採用**を Phase 3 でも継続（Phase 1 方針）。Phase 4 以降に再検討余地。
-- **Vite vs Next.js の原典差分**: 原典 §4.3 Phase 3.2 の文言「Vite + TypeScript + React」と本振り分けの実装方針（Next.js 維持）が異なる点について、`ui/Ph3/01` 内で実装方針として明示し、原典は不変扱い。気になる場合は ADR-013 候補として将来起票可能。
+- **Vite vs Next.js の原典差分**: 原典 §4.3 Phase 3.2 の文言「Vite + TypeScript + React」と本振り分けの実装方針（Next.js 維持）が異なる点について、`ui/Ph3/01` 内で実装方針として明示し、原典は不変扱い。気になる場合は将来 ADR を新規発番（ADR-013/014/015 の次番号）して起票可能。
 
 ## 11. Phase 4 への申し送り
 
-Phase 3 完了時点で API + UI が揃い、Phase 4「Polish」に着手可能。Phase 4 着手時に `docs/plans/{api,ui,worker}/Ph4/` を新設する。
+Phase 3 完了時点で API + UI が揃い、Phase 4「Polish」に着手可能。Phase 4 着手時に `<service>/docs/plans/Ph4/`（`api/docs/plans/Ph4/` / `ui/docs/plans/Ph4/` / `worker/docs/plans/Ph4/`）を新設する。
 - `api/Ph3/03` の `categorizer/rules.py` を Phase 4.1 LLM 分類サービスで再利用
 - `ui/Ph3/05` のルール編集 UI を Phase 4.2 半自動学習へ拡張
 - Playwright e2e を Phase 4 のリグレッション一式に組み込み

--- a/postgres/docs/design/01-data-model.md
+++ b/postgres/docs/design/01-data-model.md
@@ -343,7 +343,7 @@ GROUP BY h.symbol_kind;
 ## 9. マイグレーション運用方針
 
 - ツール: Alembic（SQLAlchemy が依存上含まれる前提）。Phase 1 で導入。
-- 命名: `YYYYMMDD_HHMM_<short_description>.py`
+- 命名: Alembic 既定の `<rev>_<short>.py`（`alembic revision -m "<short>"` 実行で自動採番）。
 - ロールバック: 全マイグレーションに `downgrade()` を実装。データ破壊的変更は別マイグレーションへ分離。
 - データ移行: スキーマ変更とデータ移行を同一マイグレーションに含めない（コミット粒度の原則と一致）。
 - `raw_payload` の互換性: パーサ改修時はマイグレーションでなく、ワーカ側でのリプレイスクリプトで処理する。スキーマ自体は不変。
@@ -352,5 +352,5 @@ GROUP BY h.symbol_kind;
 
 - 為替レートテーブル（`fx_rates`）は将来追加。現状はJPYのみ前提。
 - 口座番号の暗号化方式（pgcrypto等）は §10 セキュリティ設計で確定後に追加。
-- `categories` の初期データ（マスタ）は `db/seeds/categories.sql` に分離して投入する想定。
+- `categories` の初期データ（マスタ）は `postgres/src/sql/seeds/categories.sql` に分離して投入する想定（ADR-014 の per-service レイアウトに従う）。
 - LLM 分類時の `category_confidence` 閾値（自動採用 vs 未分類保留）は `worker/docs/design/03-categorization-engine.md` で定義。

--- a/postgres/docs/plans/Ph1/02-db-schema-and-migrations.md
+++ b/postgres/docs/plans/Ph1/02-db-schema-and-migrations.md
@@ -53,9 +53,9 @@ last_updated: 2026-04-30
 
 ## 後続タスク
 
-- `03-phase1-domain-types.md`（Phase 1.2 共通型: 本タスクのスキーマに対応する dataclass を定義）。
-- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: 共通型を介して間接依存）。
-- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: `transactions` テーブル定義に依存）。
+- `postgres/docs/plans/Ph1/03-domain-types.md`（Phase 1.2 共通型: 本タスクのスキーマに対応する dataclass を定義）。
+- `worker/docs/plans/Ph1/04-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: 共通型を介して間接依存）。
+- `postgres/docs/plans/Ph1/09-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: `transactions` テーブル定義に依存）。
 
 ## 対象ファイル/モジュール
 

--- a/postgres/docs/plans/Ph1/02-db-schema-and-migrations.md
+++ b/postgres/docs/plans/Ph1/02-db-schema-and-migrations.md
@@ -38,7 +38,7 @@ last_updated: 2026-04-30
 - 7 テーブルの初期スキーマ migration 一式（5 ファイル分割）を `postgres/src/alembic/versions/` 配下に追加。
 - `transactions.hash` の UNIQUE インデックス、`amount` の NUMERIC 型と CHECK 制約、`category_source` ENUM の制約定義。
 - マイグレーションの冪等性検証（2 回連続適用が無害である）。
-- スキーマ存在検証用ユニットテストフィクスチャ（dev 依存に宣言済みの `testcontainers` を用いてテスト用 Postgres コンテナを起動、または既存 `tests/_compose_utils.py` で読み込む `docker-compose.test.yml` 経由で利用）。
+- スキーマ存在検証用ユニットテストフィクスチャ（dev 依存に宣言済みの `testcontainers` を用いてテスト用 Postgres コンテナを起動、または既存 `tests/_compose_utils.py` で読み込む `compose.test.yml` 経由で利用）。
 
 ### 含まない
 
@@ -69,8 +69,8 @@ last_updated: 2026-04-30
 | `postgres/src/alembic/versions/0004_create_holdings_and_snapshots.py` | 新規 | 保有銘柄・残高スナップショット |
 | `postgres/src/alembic/versions/0005_create_categorization_rules.py` | 新規 | カテゴリルール |
 | `shared/kakeibo_shared/db/__init__.py` | 新規 | DB 接続ヘルパ（テスト用エンジン共有） |
-| `tests/unit/db/test_schema.py` | 新規 | 全テーブル・全制約の存在検証 |
-| `tests/unit/db/test_migration_idempotency.py` | 新規 | 冪等性検証 |
+| `postgres/tests/unit/db/test_schema.py` | 新規 | 全テーブル・全制約の存在検証 |
+| `postgres/tests/unit/db/test_migration_idempotency.py` | 新規 | 冪等性検証 |
 
 実装段階で具体ファイル名・分割は微調整可（マイグレーション粒度 5 分割は固定）。既存 `postgres/src/alembic/`・`postgres/src/alembic.ini`・`postgres/src/alembic/env.py` を再初期化（`alembic init`）してはならない。
 
@@ -83,13 +83,13 @@ last_updated: 2026-04-30
 5. **`category_source` ENUM**: PostgreSQL ENUM 型として `('rule', 'llm', 'manual')` を作成（`postgresql.ENUM`）。マイグレーションのダウン側で型もドロップ。
 6. **JSONB**: `transactions.raw_payload` は `JSONB` 型（ADR-004）。NULL 可、デフォルト `'{}'::jsonb`。
 7. **冪等性**: Alembic は同じ revision に対し 2 回目の `upgrade head` を no-op として扱うため、1 回目成功後 2 回目を実行してもエラーが出ないことを統合テストで確認する。
-8. **テスト用 Postgres**: ユニットテストでは dev 依存に宣言済みの `testcontainers`（pyproject.toml `[project.optional-dependencies].dev` 参照）でテスト用 Postgres コンテナを立ち上げる、または既存 `tests/_compose_utils.py` ユーティリティ経由で `docker-compose.test.yml` を起動する。テストごとに一時 DB を作成→マイグレーション適用→検証→破棄。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
+8. **テスト用 Postgres**: ユニットテストでは dev 依存に宣言済みの `testcontainers`（shared/pyproject.toml `[project.optional-dependencies].dev` 参照）でテスト用 Postgres コンテナを立ち上げる、または既存 `tests/_compose_utils.py` ユーティリティ経由で `compose.test.yml` を起動する。テストごとに一時 DB を作成→マイグレーション適用→検証→破棄。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
 
 ## 受入条件
 
 - `alembic upgrade head` が空 DB に対して成功する。
 - `alembic upgrade head` を 2 回連続で実行しても 2 回目が no-op として成功する（冪等）。
-- `pytest tests/unit/db/test_schema.py` が以下を緑で検証する。
+- `docker compose run --rm worker pytest postgres/tests/unit/db/test_schema.py` が以下を緑で検証する。
   - 7 テーブルすべての存在。
   - 各テーブルの主要カラム（`amount`, `hash`, `category_source`, `raw_payload` 等）の型と NULL 制約。
   - `transactions.hash` の UNIQUE インデックス存在。
@@ -113,7 +113,7 @@ last_updated: 2026-04-30
 
 ### TDD アプローチ
 
-- Red: マイグレーションを書く前に `test_schema.py` の検証ロジックを書き、期待スキーマと実 DB が一致しないため落ちることを確認。
+- Red: マイグレーションを書く前に `postgres/tests/unit/db/test_schema.py` の検証ロジックを書き、期待スキーマと実 DB が一致しないため落ちることを確認。
 - Green: 5 ファイルのマイグレーションを順に追加し、各段階で対応するテストが緑になることを確認。
 - Refactor: マイグレーションヘルパ（共通の ENUM 作成関数等）を抽出。
 

--- a/postgres/docs/plans/Ph1/03-domain-types.md
+++ b/postgres/docs/plans/Ph1/03-domain-types.md
@@ -65,9 +65,9 @@ last_updated: 2026-04-30
 | `shared/kakeibo_shared/domain/holding.py` | `Holding` dataclass + `SymbolKind` Enum |
 | `shared/kakeibo_shared/domain/balance_snapshot.py` | `BalanceSnapshot` dataclass |
 | `shared/kakeibo_shared/domain/currency.py` | 通貨コードバリデータ |
-| `tests/unit/domain/test_transaction.py` | `Transaction` バリデーション + `compute_hash` 決定性 |
-| `tests/unit/domain/test_holding.py` | `Holding` バリデーション + `SymbolKind` 範囲 |
-| `tests/unit/domain/test_balance_snapshot.py` | `BalanceSnapshot` バリデーション |
+| `worker/tests/unit/domain/test_transaction.py` | `Transaction` バリデーション + `compute_hash` 決定性 |
+| `worker/tests/unit/domain/test_holding.py` | `Holding` バリデーション + `SymbolKind` 範囲 |
+| `worker/tests/unit/domain/test_balance_snapshot.py` | `BalanceSnapshot` バリデーション |
 
 ## 実装方針
 

--- a/postgres/docs/plans/Ph1/03-domain-types.md
+++ b/postgres/docs/plans/Ph1/03-domain-types.md
@@ -49,12 +49,12 @@ last_updated: 2026-04-30
 
 ## 依存タスク
 
-- `02-phase1-db-schema-and-migrations.md`（Phase 1.1）。共通型は DB スキーマと一対一対応で定義するため、スキーマが先に確定している必要がある。
+- `postgres/docs/plans/Ph1/02-db-schema-and-migrations.md`（Phase 1.1）。共通型は DB スキーマと一対一対応で定義するため、スキーマが先に確定している必要がある。
 
 ## 後続タスク
 
-- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: `parse(payload) -> Iterable[Transaction]` の戻り値型として参照）。
-- `08-phase1-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性: `compute_hash` の境界条件を property-based test で網羅）。
+- `worker/docs/plans/Ph1/04-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC: `parse(payload) -> Iterable[Transaction]` の戻り値型として参照）。
+- `worker/docs/plans/Ph1/08-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性: `compute_hash` の境界条件を property-based test で網羅）。
 
 ## 対象ファイル/モジュール
 

--- a/postgres/docs/plans/Ph1/09-monthly-summary-sql.md
+++ b/postgres/docs/plans/Ph1/09-monthly-summary-sql.md
@@ -49,7 +49,7 @@ Phase1 完了条件 (c)「SQL で月次サマリが手計算と一致」を満�
 
 ## 依存タスク
 
-- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 集計対象となる `transactions` レコードを生成する手段）。
+- `worker/docs/plans/Ph1/07-ingest-cli.md`（Phase 1.6 取込CLI: 集計対象となる `transactions` レコードを生成する手段）。
 
 ## 後続タスク
 
@@ -62,11 +62,11 @@ Phase1 完了条件 (c)「SQL で月次サマリが手計算と一致」を満�
 | パス | 役割 |
 |---|---|
 | `postgres/src/sql/queries/monthly_summary.sql` | 月次サマリ SQL 本体 |
-| `src/kakeibo/sql/__init__.py` | SQL ファイル読込ヘルパ |
-| `src/kakeibo/sql/runner.py` | `run_query(filename, **params)` の実装 |
-| `tests/fixtures/sql/monthly_summary_seed.sql` | テスト用フィクスチャ（小量サンプル取引） |
+| `shared/kakeibo_shared/sql/__init__.py` | SQL ファイル読込ヘルパ（共通：api / worker から再利用） |
+| `shared/kakeibo_shared/sql/runner.py` | `run_query(filename, **params)` の実装 |
+| `tests/fixtures/sql/monthly_summary_seed.sql` | テスト用フィクスチャ（小量サンプル取引、リポジトリルートの横断 fixture） |
 | `tests/fixtures/sql/monthly_summary_expected.json` | 期待される集計結果 |
-| `tests/unit/sql/test_monthly_summary.py` | クエリ実行 + 期待結果比較 |
+| `postgres/tests/sql/test_monthly_summary.py` | クエリ実行 + 期待結果比較 |
 
 ## 実装方針
 

--- a/postgres/docs/plans/Ph2/README.md
+++ b/postgres/docs/plans/Ph2/README.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-01
 
 ## 結論：Phase2 では本サービス向けの新規実装タスクなし
 
-`compose.yml` `postgres` サービス（PostgreSQL 16-alpine）は Phase 1.1（`postgres/Ph1/01-schema-migrations.md`）でスキーマが確定する設計。Phase 2 ではメール取込（Amazon / 楽天 / Yahoo）と PayPal API 取込を `transactions` テーブルに **正規化済みの形で投入** するため、**スキーマ変更は発生しない**。
+`compose.yml` `postgres` サービス（PostgreSQL 16-alpine）は Phase 1.1（`postgres/docs/plans/Ph1/02-db-schema-and-migrations.md`）でスキーマが確定する設計。Phase 2 ではメール取込（Amazon / 楽天 / Yahoo）と PayPal API 取込を `transactions` テーブルに **正規化済みの形で投入** するため、**スキーマ変更は発生しない**。
 
 `docs/plans/01-development-plan.md` §4.2 のタスク 2.1〜2.8 をすべて確認しても、DB スキーマを拡張する項目はない。
 

--- a/ui/docs/plans/Ph2/README.md
+++ b/ui/docs/plans/Ph2/README.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 | 範囲 | Phase 2 での扱い |
 |---|---|
-| Next.js アプリ（`ui/app/`） | 変更なし |
+| Next.js アプリ（`ui/src/app/`） | 変更なし |
 | Dockerfile / `package.json` | 変更なし |
 | `tests/unit/test_ui_nextjs.py` | 既存挙動を維持 |
 

--- a/ui/docs/plans/Ph3/01-react-dashboard-scaffold.md
+++ b/ui/docs/plans/Ph3/01-react-dashboard-scaffold.md
@@ -56,8 +56,8 @@ last_updated: 2026-05-01
 | `ui/lib/query/provider.tsx` | `QueryClientProvider` |
 | `ui/components/layout/AppShell.tsx` | サイドバー + ヘッダ + コンテンツ |
 | `ui/components/feedback/{EmptyState,ErrorState,LoadingState}.tsx` | 共通状態コンポーネント |
-| `ui/app/layout.tsx` | App Router ルート（既存拡張、`AppShell` 組込） |
-| `ui/app/page.tsx` | ダッシュボードトップ（プレースホルダ → 02〜05 で内容追加） |
+| `ui/src/app/layout.tsx` | App Router ルート（既存拡張、`AppShell` 組込） |
+| `ui/src/app/page.tsx` | ダッシュボードトップ（プレースホルダ → 02〜05 で内容追加） |
 | `ui/test/setup.ts` | vitest + Testing Library セットアップ |
 | `ui/test/msw/{server,handlers}.ts` | MSW モックサーバ |
 | `ui/vitest.config.ts` | jsdom 環境、`@/` paths |
@@ -191,8 +191,8 @@ git checkout -b feature/react-dashboard-scaffold
 7. `ui/lib/query/provider.tsx` を実装
 8. `ui/components/feedback/{EmptyState,ErrorState,LoadingState}.tsx` を実装
 9. `ui/components/layout/AppShell.tsx` を実装
-10. `ui/app/layout.tsx` で `AppShell` + `QueryClientProvider` 統合
-11. `ui/app/page.tsx` をダッシュボードトップ（プレースホルダ）に
+10. `ui/src/app/layout.tsx` で `AppShell` + `QueryClientProvider` 統合
+11. `ui/src/app/page.tsx` をダッシュボードトップ（プレースホルダ）に
 
 `package.json` `scripts`：
 ```json
@@ -272,7 +272,7 @@ Phase 3.2 React Dashboard 雛形を実装。
 - ui/styles/globals.css + tailwind 設定
 - ui/test/{setup.ts, msw/*}
 - ui/vitest.config.ts
-- ui/app/{layout,page}.tsx（拡張）
+- ui/src/app/{layout,page}.tsx（拡張）
 - ui/next.config.mjs（rewrites 追加）
 
 ## 検証結果

--- a/ui/docs/plans/Ph3/02-monthly-trend-chart.md
+++ b/ui/docs/plans/Ph3/02-monthly-trend-chart.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 ## 担当サービス
 
-`compose.yml` `ui` サービス。`ui/app/balances/` に残高ページを追加し、期間フィルタ + 折れ線グラフ + 空状態 UI を実装する。
+`compose.yml` `ui` サービス。`ui/src/app/balances/` に残高ページを追加し、期間フィルタ + 折れ線グラフ + 空状態 UI を実装する。
 
 ## 上流・下流
 
@@ -45,9 +45,9 @@ last_updated: 2026-05-01
 | `ui/lib/api/balances.ts` | `useMonthlyBalances({from, to})` フック（react-query） |
 | `ui/components/charts/MonthlyTrendChart.tsx` | recharts `LineChart`（Client Component） |
 | `ui/components/charts/PeriodFilter.tsx` | 直近12か月 / 全期間 / カスタム |
-| `ui/app/balances/page.tsx` | 残高ページ（ヘッダ + フィルタ + チャート） |
+| `ui/src/app/balances/page.tsx` | 残高ページ（ヘッダ + フィルタ + チャート） |
 | `ui/components/charts/__tests__/MonthlyTrendChart.test.tsx` | Render + 空状態 + データ反映 |
-| `ui/app/balances/__tests__/page.test.tsx` | MSW モックでの統合 Render |
+| `ui/src/app/balances/__tests__/page.test.tsx` | MSW モックでの統合 Render |
 
 ## 実装方針
 
@@ -76,7 +76,7 @@ last_updated: 2026-05-01
 1. `ui/lib/api/balances.ts` で `useMonthlyBalances` フック実装（react-query + fetch ラッパ）
 2. `ui/components/charts/MonthlyTrendChart.tsx` で recharts `LineChart` 実装、`"use client"`
 3. `ui/components/charts/PeriodFilter.tsx` で期間選択 UI
-4. `ui/app/balances/page.tsx` でフィルタ + チャート統合、`searchParams` 連携
+4. `ui/src/app/balances/page.tsx` でフィルタ + チャート統合、`searchParams` 連携
 
 ### 3. Refactor
 
@@ -124,7 +124,7 @@ Phase 3.3 月次推移グラフを実装。
 ## 成果物
 - ui/lib/api/balances.ts
 - ui/components/charts/{MonthlyTrendChart,PeriodFilter}.tsx
-- ui/app/balances/page.tsx
+- ui/src/app/balances/page.tsx
 - 各 __tests__/
 
 ## 検証結果

--- a/ui/docs/plans/Ph3/03-category-spending-view.md
+++ b/ui/docs/plans/Ph3/03-category-spending-view.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 ## 担当サービス
 
-`compose.yml` `ui` サービス。`ui/app/categories/` にカテゴリ支出ページを追加。
+`compose.yml` `ui` サービス。`ui/src/app/categories/` にカテゴリ支出ページを追加。
 
 ## 上流・下流
 
@@ -46,7 +46,7 @@ last_updated: 2026-05-01
 | `ui/components/charts/CategoryStackedBar.tsx` | 積み上げ棒グラフ（recharts `BarChart` + `Bar` 複数） |
 | `ui/components/tables/CategorySpendingTable.tsx` | 表（クリックで子展開） |
 | `ui/components/MonthSelector.tsx` | 月選択 |
-| `ui/app/categories/page.tsx` | カテゴリページ |
+| `ui/src/app/categories/page.tsx` | カテゴリページ |
 | 各 `__tests__/` | Render + ドリルダウン + 未分類表示 |
 
 ## 実装方針
@@ -80,7 +80,7 @@ last_updated: 2026-05-01
 2. `ui/components/charts/CategoryStackedBar.tsx` 実装
 3. `ui/components/tables/CategorySpendingTable.tsx` 実装（行クリックで子展開）
 4. `ui/components/MonthSelector.tsx` 実装
-5. `ui/app/categories/page.tsx` で統合
+5. `ui/src/app/categories/page.tsx` で統合
 
 ### 3. Refactor
 
@@ -129,7 +129,7 @@ Phase 3.4 カテゴリ別支出ビューを実装。
 - ui/components/charts/CategoryStackedBar.tsx
 - ui/components/tables/CategorySpendingTable.tsx
 - ui/components/MonthSelector.tsx
-- ui/app/categories/page.tsx
+- ui/src/app/categories/page.tsx
 - 各 __tests__/
 
 ## 検証結果

--- a/ui/docs/plans/Ph3/04-portfolio-view.md
+++ b/ui/docs/plans/Ph3/04-portfolio-view.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 ## 担当サービス
 
-`compose.yml` `ui` サービス。`ui/app/portfolio/` にポートフォリオページを追加。
+`compose.yml` `ui` サービス。`ui/src/app/portfolio/` にポートフォリオページを追加。
 
 ## 上流・下流
 
@@ -46,7 +46,7 @@ last_updated: 2026-05-01
 | `ui/components/charts/PortfolioPieChart.tsx` | recharts `PieChart`（Client Component） |
 | `ui/components/portfolio/HoldingWarnings.tsx` | 評価額 NULL 銘柄リスト |
 | `ui/components/portfolio/SnapshotDate.tsx` | 直近スナップショット日付表示 |
-| `ui/app/portfolio/page.tsx` | ポートフォリオページ |
+| `ui/src/app/portfolio/page.tsx` | ポートフォリオページ |
 | 各 `__tests__/` | 構成比計算 + 警告 + 空状態 |
 
 ## 実装方針
@@ -84,7 +84,7 @@ last_updated: 2026-05-01
 3. `ui/lib/api/portfolio.ts` で `useHoldingComposition` 実装
 4. `ui/components/charts/PortfolioPieChart.tsx` を実装
 5. `ui/components/portfolio/{HoldingWarnings,SnapshotDate}.tsx` を実装
-6. `ui/app/portfolio/page.tsx` で統合
+6. `ui/src/app/portfolio/page.tsx` で統合
 
 ### 3. Refactor
 
@@ -134,7 +134,7 @@ Phase 3.5 ポートフォリオ構成ビューを実装。
 - ui/lib/portfolio/{composition,labels}.ts
 - ui/components/charts/PortfolioPieChart.tsx
 - ui/components/portfolio/{HoldingWarnings,SnapshotDate}.tsx
-- ui/app/portfolio/page.tsx
+- ui/src/app/portfolio/page.tsx
 - 各 __tests__/
 
 ## 検証結果

--- a/ui/docs/plans/Ph3/05-rule-editor-ui.md
+++ b/ui/docs/plans/Ph3/05-rule-editor-ui.md
@@ -19,7 +19,7 @@ last_updated: 2026-05-01
 
 ## 担当サービス
 
-`compose.yml` `ui` サービス。`ui/app/rules/` にルール一覧と編集ページを追加。`api/Ph3/01` の Rule CRUD と `api/Ph3/03` の dry-run を呼び出す。
+`compose.yml` `ui` サービス。`ui/src/app/rules/` にルール一覧と編集ページを追加。`api/Ph3/01` の Rule CRUD と `api/Ph3/03` の dry-run を呼び出す。
 
 ## 上流・下流
 
@@ -50,9 +50,9 @@ last_updated: 2026-05-01
 | `ui/components/rules/RuleList.tsx` | dnd-kit ソート可能リスト |
 | `ui/components/rules/RuleDragHandle.tsx` | ドラッグハンドル（accessibility 対応） |
 | `ui/components/rules/ApplyToExistingDialog.tsx` | 「既存取引に適用しますか？」モーダル |
-| `ui/app/rules/page.tsx` | ルール一覧 |
-| `ui/app/rules/[id]/page.tsx` | ルール編集 |
-| `ui/app/rules/new/page.tsx` | ルール新規作成 |
+| `ui/src/app/rules/page.tsx` | ルール一覧 |
+| `ui/src/app/rules/[id]/page.tsx` | ルール編集 |
+| `ui/src/app/rules/new/page.tsx` | ルール新規作成 |
 | 各 `__tests__/` | フォームバリデーション・ドラッグ並び替え・dry-run プレビュー |
 
 ## 実装方針
@@ -131,7 +131,7 @@ last_updated: 2026-05-01
 5. `ui/components/rules/RuleList.tsx` で `@dnd-kit` ベースソート
 6. `ui/components/rules/RuleDragHandle.tsx` でアクセシブルなハンドル
 7. `ui/components/rules/ApplyToExistingDialog.tsx` で確認モーダル
-8. `ui/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}` で統合
+8. `ui/src/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}` で統合
 
 ### 3. Refactor
 
@@ -185,7 +185,7 @@ Phase 3.6 ルール編集UI を実装。
 - ui/package.json（dnd-kit / react-hook-form 追加）
 - ui/lib/api/rules.ts
 - ui/components/rules/{RuleForm,RuleList,RulePreview,RuleDragHandle,ApplyToExistingDialog}.tsx
-- ui/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}
+- ui/src/app/rules/{page.tsx, [id]/page.tsx, new/page.tsx}
 - 各 __tests__/
 
 ## 検証結果

--- a/ui/docs/plans/Ph3/README.md
+++ b/ui/docs/plans/Ph3/README.md
@@ -15,7 +15,7 @@ last_updated: 2026-05-01
 
 | 範囲 | パス |
 |---|---|
-| Next.js App Router 配下のページ | `ui/app/{balances,categories,portfolio,rules}/page.tsx` 等 |
+| Next.js App Router 配下のページ | `ui/src/app/{balances,categories,portfolio,rules}/page.tsx` 等 |
 | 共通レイアウト・状態コンポーネント | `ui/components/{layout,feedback,charts,tables,rules,portfolio}/` |
 | API クライアント・型生成 | `ui/lib/api/`, `ui/lib/query/` |
 | ロジック（構成比計算など） | `ui/lib/portfolio/` |

--- a/ui/docs/plans/README.md
+++ b/ui/docs/plans/README.md
@@ -11,7 +11,7 @@ last_updated: 2026-05-01
 
 ## 結論：Phase1 では本サービス向けの新規実装タスクなし
 
-`compose.yml` `ui` サービス（Next.js / Node.js 20 LTS）は **Phase 0 で雛形が配備済み**。`ui/app/{layout.tsx,page.tsx}` の最小ページが起動するのみで、Phase 1 の MVP（CSV → DB → SQL）には UI が必要ない。
+`compose.yml` `ui` サービス（Next.js / Node.js 20 LTS）は **Phase 0 で雛形が配備済み**。`ui/src/app/{layout.tsx,page.tsx}` の最小ページが起動するのみで、Phase 1 の MVP（CSV → DB → SQL）には UI が必要ない。
 
 Phase 1 のタスク（1.1〜1.8）はすべて `postgres` または `worker` サービスに帰属する。`docs/plans/10-phase1-overview.md` §2 のタスク一覧で UI を変更する項目は存在しない。
 
@@ -19,7 +19,7 @@ Phase 1 のタスク（1.1〜1.8）はすべて `postgres` または `worker` �
 
 | 範囲 | パス |
 |---|---|
-| Next.js アプリ本体 | `ui/app/` |
+| Next.js アプリ本体 | `ui/src/app/` |
 | 設定 | `ui/{next.config.mjs, tsconfig.json, package.json, package-lock.json}` |
 | Dockerfile（multi-stage） | `ui/Dockerfile` |
 | .gitignore | `ui/.gitignore` |

--- a/worker/docs/design/02-ingest-adapters.md
+++ b/worker/docs/design/02-ingest-adapters.md
@@ -21,7 +21,7 @@ related_adrs:
 ### 2.1 IngestAdapter ABC
 
 ```python
-# adapters/base.py
+# worker/src/kakeibo_worker/adapters/base.py
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Iterable, Union
@@ -58,7 +58,7 @@ class IngestAdapter(ABC):
 ### 2.2 共通型
 
 ```python
-# adapters/types.py
+# shared/kakeibo_shared/domain/{transaction,holding,balance_snapshot}.py（dataclass を分割配置）
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from decimal import Decimal
@@ -230,7 +230,7 @@ class BalanceSnapshot:
 ### 4.1 ディレクトリ構成
 
 ```
-tests/
+tests/                            # リポジトリルート横断 fixture（ADR-014）
   fixtures/
     mufg/
       sample_001.csv
@@ -239,21 +239,28 @@ tests/
       sample_001.csv
       sample_001.expected.json
     ...
+worker/tests/                     # worker サービス専有テスト本体
+  unit/
+    adapters/
+      test_mufg.py
+      test_smbc.py
+      ...
 ```
 
 ### 4.2 テストパターン
 
 ```python
-# tests/adapters/test_mufg.py
+# worker/tests/unit/adapters/test_mufg.py
 import json
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
-from adapters.mufg import MufgCsvAdapter
+from kakeibo_worker.adapters.mufg import MufgCsvAdapter
 
-FIXTURES = Path(__file__).parent.parent / "fixtures" / "mufg"
+# 横断 fixture（リポジトリルート tests/fixtures/mufg/）を解決
+FIXTURES = Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "mufg"
 
 
 @pytest.mark.parametrize("name", ["sample_001"])
@@ -285,9 +292,9 @@ def test_mufg_golden_master(name: str) -> None:
 
 1. **ADR起草**: 取得方式（CSV/メール/API）と判断根拠をADRに残す（必要であれば）。
 2. **フィクスチャ作成**: `tests/fixtures/{code}/sample_001.{csv,eml,json}` に実データのサニタイズ済みサンプルを配置。
-3. **テスト先行**: `tests/adapters/test_{code}.py` で期待動作をassert（TDD、t-wada推奨）。
-4. **アダプタ実装**: `adapters/{code}.py` で `IngestAdapter` を実装。
-5. **登録**: `adapters/__init__.py` の `ADAPTER_REGISTRY` に登録。Watcherがファイル名 / メール送信元から該当アダプタを選択する。
+3. **テスト先行**: `worker/tests/unit/adapters/test_{code}.py` で期待動作をassert（TDD、t-wada推奨）。
+4. **アダプタ実装**: `worker/src/kakeibo_worker/adapters/{code}.py` で `IngestAdapter` を実装。
+5. **登録**: `worker/src/kakeibo_worker/adapters/__init__.py` の `ADAPTER_REGISTRY` に登録。Watcherがファイル名 / メール送信元から該当アダプタを選択する。
 6. **マスタ投入**: `institutions` テーブルに機関を追加するマイグレーション。
 7. **動作確認**: 実データ1ヶ月分を `/inbox/` に投下し、全件正しくINSERTされることを確認。
 

--- a/worker/docs/design/03-categorization-engine.md
+++ b/worker/docs/design/03-categorization-engine.md
@@ -55,7 +55,7 @@ flowchart LR
 ### 3.2 評価アルゴリズム
 
 ```python
-# categorizer/rules.py
+# api/src/kakeibo_api/categorizer/rules.py（Phase 3.6 で配置、worker からも import 可能なように Python パッケージとして export）
 import re
 from dataclasses import dataclass
 from typing import Iterable, Optional

--- a/worker/docs/design/06-reconciler.md
+++ b/worker/docs/design/06-reconciler.md
@@ -74,7 +74,7 @@ def find_link_candidates(
 ### 3.4 機関相性テーブル
 
 ```python
-# reconciler/affinity.py
+# worker/src/kakeibo_worker/reconciler/affinity.py
 KNOWN_PAIRS = {
     ("rakuten_ichiba", "rakuten_card"): 1.0,
     ("amazon", "rakuten_card"): 0.7,
@@ -235,7 +235,7 @@ CREATE TABLE reconciler_alerts (
 新しい機関相性ルール追加時、過去全データを対象に再実行できるCLIを提供:
 
 ```bash
-docker compose run --rm worker python -m reconciler.run \
+docker compose run --rm worker python -m kakeibo_worker.reconciler.run \
   --since 2026-01-01 \
   --until 2026-04-30 \
   --dry-run

--- a/worker/docs/design/07-output-integrations.md
+++ b/worker/docs/design/07-output-integrations.md
@@ -103,13 +103,13 @@ net: 130000
 ### 3.3 生成スクリプト
 
 ```python
-# tools/export_obsidian.py
+# worker/src/kakeibo_worker/tools/export_obsidian.py
 import argparse
 from datetime import date
 from pathlib import Path
 
-from app.db import session
-from app.exporters.obsidian import build_monthly_markdown
+from kakeibo_shared.db import session
+from kakeibo_worker.exporters.obsidian import build_monthly_markdown
 
 
 def main() -> None:
@@ -137,7 +137,7 @@ if __name__ == "__main__":
 毎月1日午前3時に前月分を生成:
 
 ```cron
-0 3 1 * * docker compose run --rm worker python -m tools.export_obsidian --month $(date -d 'last month' +\%Y-\%m)
+0 3 1 * * docker compose run --rm worker python -m kakeibo_worker.tools.export_obsidian --month $(date -d 'last month' +\%Y-\%m)
 ```
 
 ## 4. CSV export
@@ -170,7 +170,7 @@ if __name__ == "__main__":
 ### 4.4 CLI
 
 ```bash
-docker compose run --rm worker python -m tools.export_csv \
+docker compose run --rm worker python -m kakeibo_worker.tools.export_csv \
   --type transactions \
   --since 2026-01-01 \
   --until 2026-12-31 \
@@ -218,7 +218,7 @@ END:VCALENDAR
 | 任意期間CSV | 手動CLI |
 | 年次iCal | cron 年初 or 手動 |
 
-すべてのツールは `docker compose run --rm worker python -m tools.<name>` で起動可能。
+すべてのツールは `docker compose run --rm worker python -m kakeibo_worker.tools.<name>` で起動可能。
 
 ## 7. エラーハンドリング
 

--- a/worker/docs/design/08-ingest-flow.md
+++ b/worker/docs/design/08-ingest-flow.md
@@ -74,7 +74,7 @@ sequenceDiagram
 #### 3.1.1 watchdog 設定
 
 ```python
-# worker/watcher.py
+# worker/src/kakeibo_worker/ingest/watcher.py
 from pathlib import Path
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -212,6 +212,8 @@ CREATE TABLE worker_state (
 INSERT INTO worker_state (key, value) VALUES ('paypal.last_run', '2026-04-29T23:30:00Z');
 ```
 
+スキーマ本体は ADR-014 に従い `postgres/src/alembic/versions/` 配下のマイグレーションで管理する（worker サービスからは Raw SQL で読み書きするのみ）。
+
 PayPal Transactions API は最大31日前までの遡及が可能。日次で十分な範囲。
 
 ### 3.4 手動入力UI
@@ -288,7 +290,7 @@ flowchart LR
 ### 5.2 リトライ戦略
 
 ```python
-# worker/retry.py
+# worker/src/kakeibo_worker/retry.py
 import time
 import random
 
@@ -348,12 +350,12 @@ cron 設定は worker コンテナ内で `cron` または `supervisor` で管理
 
 ```cron
 # worker/crontab
-0 23 * * * /usr/local/bin/python -m worker.tasks.fetch_mail
-30 23 * * * /usr/local/bin/python -m worker.tasks.fetch_paypal
-45 23 * * * /usr/local/bin/python -m worker.tasks.reconcile
-30 0 * * * /usr/local/bin/python -m worker.tasks.classify_unclassified
-0 4 * * 0 /usr/local/bin/python -m worker.tasks.verify_balance
-0 3 1 * * /usr/local/bin/python -m tools.export_obsidian --month $(date -d 'last month' +\%Y-\%m)
+0 23 * * * /usr/local/bin/python -m kakeibo_worker.tasks.fetch_mail
+30 23 * * * /usr/local/bin/python -m kakeibo_worker.tasks.fetch_paypal
+45 23 * * * /usr/local/bin/python -m kakeibo_worker.tasks.reconcile
+30 0 * * * /usr/local/bin/python -m kakeibo_worker.tasks.classify_unclassified
+0 4 * * 0 /usr/local/bin/python -m kakeibo_worker.tasks.verify_balance
+0 3 1 * * /usr/local/bin/python -m kakeibo_worker.tools.export_obsidian --month $(date -d 'last month' +\%Y-\%m)
 ```
 
 ## 7. 取込のアトミック性

--- a/worker/docs/plans/Ph1/04-ingest-adapter-base.md
+++ b/worker/docs/plans/Ph1/04-ingest-adapter-base.md
@@ -49,12 +49,12 @@ ADR-007（アダプタパターン）に従い、機関別取込実装の共通�
 
 ## 依存タスク
 
-- `03-phase1-domain-types.md`（Phase 1.2）。`Transaction` / `Holding` 型がないと抽象メソッドの戻り値型が書けない。
+- `postgres/docs/plans/Ph1/03-domain-types.md`（Phase 1.2）。`Transaction` / `Holding` 型がないと抽象メソッドの戻り値型が書けない。
 
 ## 後続タスク
 
-- `05-phase1-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
-- `06-phase1-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
+- `worker/docs/plans/Ph1/05-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
+- `worker/docs/plans/Ph1/06-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
 - Phase 2 系のメール・API アダプタ（本プラン群の対象外、`01-development-plan.md` §4.2 で扱う）。
 
 ## 対象ファイル/モジュール

--- a/worker/docs/plans/Ph1/04-ingest-adapter-base.md
+++ b/worker/docs/plans/Ph1/04-ingest-adapter-base.md
@@ -63,9 +63,9 @@ ADR-007（アダプタパターン）に従い、機関別取込実装の共通�
 |---|---|
 | `worker/src/kakeibo_worker/adapters/__init__.py` | パッケージ初期化 |
 | `worker/src/kakeibo_worker/adapters/base.py` | `IngestAdapter` ABC 本体 + `source` 属性検証メタクラス（or `__init_subclass__`） |
-| `tests/unit/adapters/__init__.py` | テストパッケージ初期化 |
-| `tests/unit/adapters/test_base.py` | 契約検証（抽象メソッド未実装サブクラスのインスタンス化失敗、`source` 必須） |
-| `tests/unit/adapters/_dummy_adapter.py` | テスト用ダミーアダプタ |
+| `worker/tests/unit/adapters/__init__.py` | テストパッケージ初期化 |
+| `worker/tests/unit/adapters/test_base.py` | 契約検証（抽象メソッド未実装サブクラスのインスタンス化失敗、`source` 必須） |
+| `worker/tests/unit/adapters/_dummy_adapter.py` | テスト用ダミーアダプタ |
 
 ## 実装方針
 
@@ -74,7 +74,7 @@ ADR-007（アダプタパターン）に従い、機関別取込実装の共通�
 3. **`account_id` 注入**: コンストラクタ引数 `account_id` をサブクラス共通で受け取り、`Transaction` 生成時に `self.account_id` を参照する。`parse(payload, account_id=...)` のような可変引数注入や `parse(payload, **context)` 拡張は採用しない（契約の単純化のため）。
 4. **デフォルト実装**: `extract_holdings` は銀行アダプタには無関係なため、デフォルトで空 `Iterable` を返す具体メソッドにする選択肢もあるが、抽象を保ち各サブクラスで `return ()` を明示する方を採用（明示が型安全）。
 5. **エラー型**: パース失敗時はサブクラスが `kakeibo_worker.adapters.errors.AdapterError`（同タスクで定義）を送出する規約とする。型は本タスクで宣言、利用は Phase 1.4 以降。
-6. **ダミーアダプタ**: `tests/unit/adapters/_dummy_adapter.py` に `class DummyAdapter(IngestAdapter)` を実装し、`parse` が固定の `Transaction` リストを返す。`source = "dummy"`、コンストラクタは `DummyAdapter(account_id=...)` で受ける。
+6. **ダミーアダプタ**: `worker/tests/unit/adapters/_dummy_adapter.py` に `class DummyAdapter(IngestAdapter)` を実装し、`parse` が固定の `Transaction` リストを返す。`source = "dummy"`、コンストラクタは `DummyAdapter(account_id=...)` で受ける。
 
 ## 受入条件
 
@@ -97,7 +97,7 @@ ADR-007（アダプタパターン）に従い、機関別取込実装の共通�
 
 ### TDD アプローチ
 
-- Red: `tests/unit/adapters/test_base.py` を先に書き、`from kakeibo_worker.adapters.base import IngestAdapter` で ImportError を起こす。
+- Red: `worker/tests/unit/adapters/test_base.py` を先に書き、`from kakeibo_worker.adapters.base import IngestAdapter` で ImportError を起こす。
 - Green: `IngestAdapter` ABC を最小限で実装、各テストを順に通す。
 - Refactor: `__init_subclass__` 内のバリデーションを別関数に抽出可能なら抽出。
 

--- a/worker/docs/plans/Ph1/05-mufg-csv-adapter.md
+++ b/worker/docs/plans/Ph1/05-mufg-csv-adapter.md
@@ -50,11 +50,11 @@ last_updated: 2026-04-30
 
 ## 依存タスク
 
-- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
+- `worker/docs/plans/Ph1/04-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
 
 ## 後続タスク
 
-- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
+- `worker/docs/plans/Ph1/07-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
 
 ## 対象ファイル/モジュール
 
@@ -69,13 +69,13 @@ last_updated: 2026-04-30
 
 ## 実装方針
 
-1. **`MufgCsvAdapter` クラス**: `IngestAdapter` を継承、`source: ClassVar[str] = "mufg"` を宣言。コンストラクタは ABC 由来の `__init__(self, *, account_id: int)` をそのまま利用し、追加の引数は取らない（`04-phase1-ingest-adapter-base.md` の契約に従う）。`parse(payload: bytes) -> Iterable[Transaction]` を実装し、`account_id` は `self.account_id` から参照する。`extract_holdings` は空のイテラブルを返す。
+1. **`MufgCsvAdapter` クラス**: `IngestAdapter` を継承、`source: ClassVar[str] = "mufg"` を宣言。コンストラクタは ABC 由来の `__init__(self, *, account_id: int)` をそのまま利用し、追加の引数は取らない（`worker/docs/plans/Ph1/04-ingest-adapter-base.md` の契約に従う）。`parse(payload: bytes) -> Iterable[Transaction]` を実装し、`account_id` は `self.account_id` から参照する。`extract_holdings` は空のイテラブルを返す。
 2. **デコード**: `payload.decode("shift_jis")` を `try/except UnicodeDecodeError` で囲み、失敗時は `EncodingMismatchError` を送出。chardet 等の自動判定は **使わない**（リスク R-08 の方針）。
 3. **CSV 解析**: `csv.DictReader` で行イテレーション。MUFG の実フォーマットの列名（例: `日付`, `摘要`, `お支払金額`, `お預り金額`, `差引残高`）を定数化。列が欠損していたら `ColumnMissingError`。
 4. **金額正規化**: 出金額カラムが空でない場合 `amount = -Decimal(value.replace(",", ""))`、入金額カラムが空でない場合 `amount = Decimal(value.replace(",", ""))`。両方空 / 両方ある行は不正データとして例外。
 5. **日付**: `datetime.strptime(row["日付"], "%Y/%m/%d").date()`。年が 2 桁表記の場合は別フォーマットを試行（実 CSV を確認後、フィクスチャに反映）。
 6. **`description` 正規化**: 前後の全角・半角空白除去は **行わない**（ADR-006 の境界条件は Phase 1.7 で確定）。摘要をそのまま採用。
-7. **ハッシュ**: `compute_hash(account_id, occurred_on, amount, description)` を呼ぶ。`account_id` は ABC のコンストラクタで注入された `self.account_id` を参照する（`04-phase1-ingest-adapter-base.md` で確定済の契約）。`parse` 引数で `account_id` を受け取る、または `parse(payload, **context)` への拡張は採用しない。CLI（Phase 1.6）は `MufgCsvAdapter(account_id=...)` でインスタンス化してから `parse(payload)` を呼ぶ。
+7. **ハッシュ**: `compute_hash(account_id, occurred_on, amount, description)` を呼ぶ。`account_id` は ABC のコンストラクタで注入された `self.account_id` を参照する（`worker/docs/plans/Ph1/04-ingest-adapter-base.md` で確定済の契約）。`parse` 引数で `account_id` を受け取る、または `parse(payload, **context)` への拡張は採用しない。CLI（Phase 1.6）は `MufgCsvAdapter(account_id=...)` でインスタンス化してから `parse(payload)` を呼ぶ。
 8. **ゴールデンマスタ**: `tests/fixtures/mufg/sample.csv` に Shift_JIS で 5〜10 行の合成データを置き、`expected.json` と照合。
 
 ## 受入条件

--- a/worker/docs/plans/Ph1/05-mufg-csv-adapter.md
+++ b/worker/docs/plans/Ph1/05-mufg-csv-adapter.md
@@ -65,7 +65,7 @@ last_updated: 2026-04-30
 | `tests/fixtures/mufg/sample.csv` | Shift_JIS のゴールデンマスタ（合成データ） |
 | `tests/fixtures/mufg/expected.json` | 期待される `Transaction` リスト（フィールドのスナップショット） |
 | `tests/fixtures/mufg/broken_encoding.csv` | エラーパス用（UTF-8 として作成） |
-| `tests/unit/adapters/test_mufg.py` | ゴールデンマスタテスト + エラーパステスト |
+| `worker/tests/unit/adapters/test_mufg.py` | ゴールデンマスタテスト + エラーパステスト |
 
 ## 実装方針
 

--- a/worker/docs/plans/Ph1/06-smbc-csv-adapter.md
+++ b/worker/docs/plans/Ph1/06-smbc-csv-adapter.md
@@ -61,7 +61,7 @@ last_updated: 2026-04-30
 | `worker/src/kakeibo_worker/adapters/smbc.py` | `SmbcCsvAdapter` 実装 |
 | `tests/fixtures/smbc/sample.csv` | SMBC ゴールデンマスタ（合成データ） |
 | `tests/fixtures/smbc/expected.json` | 期待される `Transaction` リスト |
-| `tests/unit/adapters/test_smbc.py` | ゴールデンマスタ + 列差分検証 + 摘要正規化テスト |
+| `worker/tests/unit/adapters/test_smbc.py` | ゴールデンマスタ + 列差分検証 + 摘要正規化テスト |
 
 ## 実装方針
 

--- a/worker/docs/plans/Ph1/06-smbc-csv-adapter.md
+++ b/worker/docs/plans/Ph1/06-smbc-csv-adapter.md
@@ -47,12 +47,12 @@ last_updated: 2026-04-30
 
 ## 依存タスク
 
-- `04-phase1-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
-- `05-phase1-mufg-csv-adapter.md`（Phase 1.4）とは独立で並行可能だが、参考実装として参照する。
+- `worker/docs/plans/Ph1/04-ingest-adapter-base.md`（Phase 1.3 IngestAdapter ABC）。
+- `worker/docs/plans/Ph1/05-mufg-csv-adapter.md`（Phase 1.4）とは独立で並行可能だが、参考実装として参照する。
 
 ## 後続タスク
 
-- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
+- `worker/docs/plans/Ph1/07-ingest-cli.md`（Phase 1.6 取込CLI: 本アダプタを呼び出して DB 永続化）。
 
 ## 対象ファイル/モジュール
 

--- a/worker/docs/plans/Ph1/07-ingest-cli.md
+++ b/worker/docs/plans/Ph1/07-ingest-cli.md
@@ -51,13 +51,13 @@ last_updated: 2026-04-30
 
 ## 依存タスク
 
-- `05-phase1-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
-- `06-phase1-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
+- `worker/docs/plans/Ph1/05-mufg-csv-adapter.md`（Phase 1.4 MUFG CSV アダプタ）。
+- `worker/docs/plans/Ph1/06-smbc-csv-adapter.md`（Phase 1.5 SMBC CSV アダプタ）。
 
 ## 後続タスク
 
-- `08-phase1-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性ユニットテスト強化）。
-- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 本 CLI で投入したデータを集計）。
+- `worker/docs/plans/Ph1/08-hash-idempotency-tests.md`（Phase 1.7 ハッシュ冪等性ユニットテスト強化）。
+- `postgres/docs/plans/Ph1/09-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 本 CLI で投入したデータを集計）。
 - Phase 2.1 Watcher（本プラン群の対象外、`01-development-plan.md` §4.2 で扱う）。
 
 ## 対象ファイル/モジュール

--- a/worker/docs/plans/Ph1/07-ingest-cli.md
+++ b/worker/docs/plans/Ph1/07-ingest-cli.md
@@ -68,8 +68,8 @@ last_updated: 2026-04-30
 | `worker/src/kakeibo_worker/ingest/cli.py` | CLI エントリ。`if __name__ == "__main__": ...` を含む |
 | `worker/src/kakeibo_worker/ingest/registry.py` | 機関 → アダプタクラスのレジストリ |
 | `worker/src/kakeibo_worker/ingest/persister.py` | DB 永続化（`ON CONFLICT (hash) DO NOTHING`） |
-| `tests/unit/ingest/test_cli.py` | CLI 引数 / 終了コード / dry-run テスト |
-| `tests/unit/ingest/test_persister.py` | 冪等 INSERT 検証（実 Postgres or テスト用 DB） |
+| `worker/tests/unit/ingest/test_cli.py` | CLI 引数 / 終了コード / dry-run テスト |
+| `worker/tests/unit/ingest/test_persister.py` | 冪等 INSERT 検証（実 Postgres or テスト用 DB） |
 
 ## 実装方針
 
@@ -80,7 +80,7 @@ last_updated: 2026-04-30
 5. **dry-run**: `--dry-run` 指定時は `persister.persist(...)` をスキップし、`len(transactions)` と先頭 3 件を `print` する。
 6. **終了コード**: `click` の例外ハンドリングで `EncodingMismatchError` / `ColumnMissingError` → exit 3、`psycopg.Error` → exit 4、その他 `SystemExit(2)` は引数不正。
 7. **ログ**: `logging.getLogger("kakeibo_worker.ingest")` を使用し、構造化ログ（INFO で件数、WARNING で重複スキップ件数）。
-8. **テストでの DB**: dev 依存に宣言済みの `testcontainers`（pyproject.toml `[project.optional-dependencies].dev`）または既存 `tests/_compose_utils.py` を活用し、テストごとに一時 DB を立ち上げて Phase 1.1 のマイグレーションを適用。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
+8. **テストでの DB**: dev 依存に宣言済みの `testcontainers`（shared/pyproject.toml `[project.optional-dependencies].dev`）または既存 `tests/_compose_utils.py`（リポジトリルートの横断ユーティリティ）を活用し、テストごとに一時 DB を立ち上げて Phase 1.1 のマイグレーションを適用。`pytest-postgresql` は dev 依存に未宣言のため採用しない。
 
 ## 受入条件
 
@@ -104,7 +104,7 @@ last_updated: 2026-04-30
 
 ### TDD アプローチ
 
-- Red: `tests/unit/ingest/test_cli.py` で `CliRunner` ベースのテストを書き、CLI 未実装で落とす。
+- Red: `worker/tests/unit/ingest/test_cli.py` で `CliRunner` ベースのテストを書き、CLI 未実装で落とす。
 - Green: `cli.py` を最小実装（成功パスのみ）→ 冪等性 → エラーパスの順に実装。
 - Refactor: 永続化ロジックを `persister.py` に切り出し、CLI は引数解釈に専念。
 

--- a/worker/docs/plans/Ph1/08-hash-idempotency-tests.md
+++ b/worker/docs/plans/Ph1/08-hash-idempotency-tests.md
@@ -51,12 +51,12 @@ last_updated: 2026-04-30
 
 ## 依存タスク
 
-- `03-phase1-domain-types.md`（Phase 1.2 共通型: `compute_hash` の実装が前提）。
-- `07-phase1-ingest-cli.md`（Phase 1.6 取込CLI: 実運用の入力データを参考に境界条件を抽出）。
+- `postgres/docs/plans/Ph1/03-domain-types.md`（Phase 1.2 共通型: `compute_hash` の実装が前提）。
+- `worker/docs/plans/Ph1/07-ingest-cli.md`（Phase 1.6 取込CLI: 実運用の入力データを参考に境界条件を抽出）。
 
 ## 後続タスク
 
-- `09-phase1-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 冪等性が保証されてから集計の正確性を検証）。
+- `postgres/docs/plans/Ph1/09-monthly-summary-sql.md`（Phase 1.8 月次サマリ SQL: 冪等性が保証されてから集計の正確性を検証）。
 - Phase 4.4 残高整合性レポート（本プラン群の対象外）が冪等性の保険を活用する。
 
 ## 対象ファイル/モジュール

--- a/worker/docs/plans/Ph1/08-hash-idempotency-tests.md
+++ b/worker/docs/plans/Ph1/08-hash-idempotency-tests.md
@@ -63,8 +63,8 @@ last_updated: 2026-04-30
 
 | パス | 役割 |
 |---|---|
-| `tests/unit/domain/test_hash.py` | property-based test 本体（hypothesis 利用） |
-| `tests/unit/domain/test_hash_boundary.py` | 境界条件の表駆動テスト（半角・全角空白、Unicode 正規化等） |
+| `worker/tests/unit/domain/test_hash.py` | property-based test 本体（hypothesis 利用） |
+| `worker/tests/unit/domain/test_hash_boundary.py` | 境界条件の表駆動テスト（半角・全角空白、Unicode 正規化等） |
 | `pyproject.toml` | 既存・参照のみ。hypothesis は `[project.optional-dependencies].dev` に `"hypothesis>=6.100,<7"` として既に宣言済みのため変更不要（`[tool.uv.dev-dependencies]` セクションは存在しない） |
 | `shared/kakeibo_shared/domain/transaction.py` | `compute_hash` 本体（Phase 1.2 で実装済）。本タスクで判明した境界条件に応じて正規化方針を反映する場合のみ変更 |
 
@@ -98,14 +98,14 @@ last_updated: 2026-04-30
 
 ### ユニットテスト（テスト先行）
 
-1. **`test_hash.py`**: hypothesis ベースの property-based test。決定性 + 1 引数違いでの分離 + 衝突ゼロ。
-2. **`test_hash_boundary.py`**: 表駆動テストで以下を検証。
+1. **`worker/tests/unit/domain/test_hash.py`**: hypothesis ベースの property-based test。決定性 + 1 引数違いでの分離 + 衝突ゼロ。
+2. **`worker/tests/unit/domain/test_hash_boundary.py`**: 表駆動テストで以下を検証。
    - 半角空白前後差異（"foo" vs " foo "）。
    - 全角空白を含む（"foo　bar" vs "foo bar"）。
    - 改行コード差異。
    - Unicode 結合文字（"が" vs "か" + 濁点）。
    - 空文字 description の扱い。
-3. **`test_hash.py` の通貨注記**: 同入力で `currency` だけが違うケースは現行 API では区別されないことを `pytest.mark.xfail` または `assert ==` で明示し、コメントで設計意図を残す。
+3. **`worker/tests/unit/domain/test_hash.py` の通貨注記**: 同入力で `currency` だけが違うケースは現行 API では区別されないことを `pytest.mark.xfail` または `assert ==` で明示し、コメントで設計意図を残す。
 
 ### TDD アプローチ
 

--- a/worker/docs/plans/Ph2/01-watcher-service.md
+++ b/worker/docs/plans/Ph2/01-watcher-service.md
@@ -51,9 +51,9 @@ last_updated: 2026-05-01
 | `worker/src/kakeibo_worker/ingest/watcher.py` | watchdog `Observer` ベースの Watcher 本体 |
 | `worker/src/kakeibo_worker/ingest/dispatch.py` | ディレクトリ名 → 機関コード判定 + 取込CLI 起動 |
 | `worker/src/kakeibo_worker/main.py` | heartbeat ループに Watcher 起動を統合（既存の API は維持） |
-| `tests/unit/ingest/test_watcher.py` | watchdog をモックしてイベント発火検証 |
-| `tests/unit/ingest/test_dispatch.py` | 機関コード判定とリトライ |
-| `tests/integration/watcher/test_watcher_e2e.py` | `tmp_path` で実ファイル投下 → DB 反映の統合テスト |
+| `worker/tests/unit/ingest/test_watcher.py` | watchdog をモックしてイベント発火検証 |
+| `worker/tests/unit/ingest/test_dispatch.py` | 機関コード判定とリトライ |
+| `worker/tests/integration/watcher/test_watcher_e2e.py` | `tmp_path` で実ファイル投下 → DB 反映の統合テスト |
 
 ## 実装方針
 
@@ -69,9 +69,9 @@ last_updated: 2026-05-01
 
 ### 1. Red
 
-- `tests/unit/ingest/test_watcher.py` で `watchdog.events.FileSystemEvent` を直接ハンドラに渡し、ディスパッチが期待通り呼ばれることを `unittest.mock.MagicMock` で検証。
-- `tests/unit/ingest/test_dispatch.py` で機関コード判定 / 未対応機関で dead_letter 行き / リトライ挙動を検証。
-- `tests/integration/watcher/test_watcher_e2e.py` で `tmp_path` 配下に `mufg/sample.csv` を配置 → 5 秒以内に testcontainers Postgres へ取引が INSERT されることを確認（前提: `worker/Ph1/05` 完了で取込CLI が動く）。
+- `worker/tests/unit/ingest/test_watcher.py` で `watchdog.events.FileSystemEvent` を直接ハンドラに渡し、ディスパッチが期待通り呼ばれることを `unittest.mock.MagicMock` で検証。
+- `worker/tests/unit/ingest/test_dispatch.py` で機関コード判定 / 未対応機関で dead_letter 行き / リトライ挙動を検証。
+- `worker/tests/integration/watcher/test_watcher_e2e.py` で `tmp_path` 配下に `mufg/sample.csv` を配置 → 5 秒以内に testcontainers Postgres へ取引が INSERT されることを確認（前提: `worker/Ph1/05` 完了で取込CLI が動く）。
 - 全件赤になることを確認。
 
 ### 2. Green
@@ -98,10 +98,10 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/ingest/test_watcher.py tests/unit/ingest/test_dispatch.py
-pytest tests/integration/watcher/      # testcontainers 起動含む
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/ingest/test_watcher.py worker/tests/unit/ingest/test_dispatch.py
+docker compose run --rm worker pytest worker/tests/integration/watcher/      # testcontainers 起動含む
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -124,8 +124,8 @@ Phase 2.1 watchdog Watcher サービスを実装。
 - pyproject.toml（watchdog 追加）
 - worker/src/kakeibo_worker/ingest/{watcher,dispatch}.py
 - worker/src/kakeibo_worker/main.py（拡張）
-- tests/unit/ingest/test_watcher.py / test_dispatch.py
-- tests/integration/watcher/test_watcher_e2e.py
+- worker/tests/unit/ingest/test_watcher.py / test_dispatch.py
+- worker/tests/integration/watcher/test_watcher_e2e.py
 
 ## 検証結果
 - pytest（unit + integration）: 全件緑

--- a/worker/docs/plans/Ph2/02-archive-and-dead-letter.md
+++ b/worker/docs/plans/Ph2/02-archive-and-dead-letter.md
@@ -44,8 +44,8 @@ last_updated: 2026-05-01
 |---|---|
 | `worker/src/kakeibo_worker/ingest/archiver.py` | `archive_success(path)`, `archive_failure(path, error)` の純関数 |
 | `worker/src/kakeibo_worker/ingest/watcher.py` | （既存）archiver 呼び出しを統合 |
-| `tests/unit/ingest/test_archiver.py` | 成功 / 失敗 / 衝突 / エラーログ併置テスト |
-| `tests/integration/archiver/test_archiver_e2e.py` | tmp_path で実ファイル移動を検証 |
+| `worker/tests/unit/ingest/test_archiver.py` | 成功 / 失敗 / 衝突 / エラーログ併置テスト |
+| `worker/tests/integration/archiver/test_archiver_e2e.py` | tmp_path で実ファイル移動を検証 |
 
 ## 実装方針
 
@@ -60,12 +60,12 @@ last_updated: 2026-05-01
 
 ### 1. Red
 
-- `tests/unit/ingest/test_archiver.py`：
+- `worker/tests/unit/ingest/test_archiver.py`：
   - 成功時に `archive_path / mufg / 2026-05 / sample.csv` に移動、inbox から消滅
   - 失敗時に `dead_letter_path / sample.csv` + `sample.csv.error.log`
   - 同名衝突時にタイムスタンプ付きリネーム
   - `error.log` にトークン文字列が含まれていないこと（pytest fixture でログを inspect）
-- `tests/integration/archiver/test_archiver_e2e.py` で実ファイル移動。
+- `worker/tests/integration/archiver/test_archiver_e2e.py` で実ファイル移動。
 
 ### 2. Green
 
@@ -88,9 +88,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/ingest/test_archiver.py tests/integration/archiver/
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/ingest/test_archiver.py worker/tests/integration/archiver/
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -110,8 +110,8 @@ Phase 2.2 アーカイブ移動 + dead letter を実装。
 
 ## 成果物
 - worker/src/kakeibo_worker/ingest/archiver.py
-- tests/unit/ingest/test_archiver.py
-- tests/integration/archiver/test_archiver_e2e.py
+- worker/tests/unit/ingest/test_archiver.py
+- worker/tests/integration/archiver/test_archiver_e2e.py
 
 ## 検証結果
 - 全件緑（unit + integration）

--- a/worker/docs/plans/Ph2/03-gmail-mcp-client.md
+++ b/worker/docs/plans/Ph2/03-gmail-mcp-client.md
@@ -50,9 +50,9 @@ last_updated: 2026-05-01
 | `worker/src/kakeibo_worker/adapters/gmail/__init__.py` | パッケージ初期化 |
 | `worker/src/kakeibo_worker/adapters/gmail/client.py` | OAuth トークン読込 + Gmail API 呼出 |
 | `worker/src/kakeibo_worker/adapters/gmail/auth.py` | リフレッシュトークン → アクセストークン変換、ログマスキング |
-| `tests/unit/adapters/gmail/test_client.py` | API レスポンスをモックして `RawMail` 正規化検証 |
-| `tests/unit/adapters/gmail/test_auth.py` | トークンマスキング検証（ログキャプチャ） |
-| `tests/fixtures/gmail/sample_message.json` | Gmail API `users.messages.get` レスポンスの fixture |
+| `worker/tests/unit/adapters/gmail/test_client.py` | API レスポンスをモックして `RawMail` 正規化検証 |
+| `worker/tests/unit/adapters/gmail/test_auth.py` | トークンマスキング検証（ログキャプチャ） |
+| `tests/fixtures/gmail/sample_message.json` | Gmail API `users.messages.get` レスポンスの fixture（横断 fixture） |
 
 ## 実装方針
 
@@ -68,14 +68,14 @@ last_updated: 2026-05-01
 ### 1. Red
 
 - `tests/fixtures/gmail/sample_message.json` を Gmail API `users.messages.get` のサンプル形式で作成（合成。実メールデータは入れない）。
-- `tests/unit/adapters/gmail/test_client.py`：
+- `worker/tests/unit/adapters/gmail/test_client.py`：
   - `client.list_messages(query="...")` がメッセージ ID リストを返す（HTTP モック）
   - `client.get_message(msg_id)` が `RawMail` を返す
   - スコープ違反のクライアントを inject すると `ValueError`
-- `tests/unit/adapters/gmail/test_auth.py`：
+- `worker/tests/unit/adapters/gmail/test_auth.py`：
   - リフレッシュトークン JSON 読込でトークン値が `caplog` に含まれない
   - 期限切れトークンで `RuntimeError`
-- `tests/unit/domain/test_raw_mail.py` で `RawMail` バリデーション。
+- `worker/tests/unit/domain/test_raw_mail.py` で `RawMail` バリデーション。
 
 ### 2. Green
 
@@ -101,9 +101,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/adapters/gmail/ tests/unit/domain/test_raw_mail.py
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/adapters/gmail/ worker/tests/unit/domain/test_raw_mail.py
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -125,8 +125,8 @@ Phase 2.3 Gmail 読み取り専用クライアントを実装。
 ## 成果物
 - shared/kakeibo_shared/domain/raw_mail.py
 - worker/src/kakeibo_worker/adapters/gmail/{client,auth}.py
-- tests/unit/{domain/test_raw_mail.py, adapters/gmail/}
-- tests/fixtures/gmail/sample_message.json
+- worker/tests/unit/{domain/test_raw_mail.py, adapters/gmail/}
+- tests/fixtures/gmail/sample_message.json（横断 fixture）
 - pyproject.toml（mail extras 拡張）
 
 ## 検証結果

--- a/worker/docs/plans/Ph2/04-parser-amazon-mail.md
+++ b/worker/docs/plans/Ph2/04-parser-amazon-mail.md
@@ -51,7 +51,7 @@ last_updated: 2026-05-01
 | `tests/fixtures/mail/amazon/multiple_items.eml` | 複数商品 |
 | `tests/fixtures/mail/amazon/gift_card.eml` | ギフト券利用 |
 | `tests/fixtures/mail/amazon/expected.json` | 期待 Transaction 配列 |
-| `tests/unit/adapters/mail/test_amazon.py` | ゴールデンマスタ + エッジケース |
+| `worker/tests/unit/adapters/mail/test_amazon.py` | ゴールデンマスタ + エッジケース |
 
 ## 実装方針
 
@@ -77,7 +77,7 @@ last_updated: 2026-05-01
 
 - `tests/fixtures/mail/amazon/{normal,multiple_items,gift_card}.eml` を合成データで作成（実注文情報禁止）。
 - `tests/fixtures/mail/amazon/expected.json` に期待 Transaction を記述。
-- `tests/unit/adapters/mail/test_amazon.py`：
+- `worker/tests/unit/adapters/mail/test_amazon.py`：
   - 3 パターン全てでゴールデンマスタ完全一致
   - 金額が `Decimal`、購入は負値
   - 注文番号が `raw_payload["order_id"]` に保持される
@@ -107,9 +107,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/adapters/mail/test_amazon.py
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/adapters/mail/test_amazon.py
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -131,7 +131,7 @@ Phase 2.4 Amazon 注文確認メールパーサを実装。
 - worker/src/kakeibo_worker/adapters/mail/amazon.py
 - tests/fixtures/mail/amazon/{normal,multiple_items,gift_card}.eml
 - tests/fixtures/mail/amazon/expected.json
-- tests/unit/adapters/mail/test_amazon.py
+- worker/tests/unit/adapters/mail/test_amazon.py
 
 ## 検証結果
 - 3 パターン全件緑

--- a/worker/docs/plans/Ph2/05-parser-rakuten-mail.md
+++ b/worker/docs/plans/Ph2/05-parser-rakuten-mail.md
@@ -44,7 +44,7 @@ last_updated: 2026-05-01
 | `tests/fixtures/mail/rakuten/normal.eml` | ポイント利用なし合成メール |
 | `tests/fixtures/mail/rakuten/with_points.eml` | ポイント利用あり |
 | `tests/fixtures/mail/rakuten/expected.json` | 期待 Transaction 配列 |
-| `tests/unit/adapters/mail/test_rakuten.py` | ゴールデンマスタ + ポイント利用 + ハッシュ決定性 |
+| `worker/tests/unit/adapters/mail/test_rakuten.py` | ゴールデンマスタ + ポイント利用 + ハッシュ決定性 |
 
 ## 実装方針
 
@@ -69,7 +69,7 @@ last_updated: 2026-05-01
 
 - `tests/fixtures/mail/rakuten/{normal,with_points}.eml` を合成。
 - `tests/fixtures/mail/rakuten/expected.json` に期待値（ポイント利用額を含む）。
-- `tests/unit/adapters/mail/test_rakuten.py`：
+- `worker/tests/unit/adapters/mail/test_rakuten.py`：
   - ポイント利用なし: `raw_payload["points_used"] == "0"` / `amount == -商品合計`
   - ポイント利用あり: `raw_payload["points_used"] == "<利用額>"` / `amount == -支払金額`
   - 注文番号別で別ハッシュ
@@ -96,9 +96,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/adapters/mail/test_rakuten.py
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/adapters/mail/test_rakuten.py
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -119,7 +119,7 @@ Phase 2.5 楽天市場 注文確認メールパーサを実装。
 - worker/src/kakeibo_worker/adapters/mail/rakuten.py
 - tests/fixtures/mail/rakuten/{normal,with_points}.eml
 - tests/fixtures/mail/rakuten/expected.json
-- tests/unit/adapters/mail/test_rakuten.py
+- worker/tests/unit/adapters/mail/test_rakuten.py
 
 ## 検証結果
 - 全件緑（2 パターン）

--- a/worker/docs/plans/Ph2/06-parser-yahoo-mail.md
+++ b/worker/docs/plans/Ph2/06-parser-yahoo-mail.md
@@ -44,7 +44,7 @@ last_updated: 2026-05-01
 | `tests/fixtures/mail/yahoo/normal.eml` | PayPay ポイントなし合成メール |
 | `tests/fixtures/mail/yahoo/with_paypay_points.eml` | PayPay ポイント利用あり |
 | `tests/fixtures/mail/yahoo/expected.json` | 期待 Transaction 配列 |
-| `tests/unit/adapters/mail/test_yahoo.py` | ゴールデンマスタ + PayPay ポイント + ハッシュ決定性 |
+| `worker/tests/unit/adapters/mail/test_yahoo.py` | ゴールデンマスタ + PayPay ポイント + ハッシュ決定性 |
 
 ## 実装方針
 
@@ -69,7 +69,7 @@ last_updated: 2026-05-01
 
 - `tests/fixtures/mail/yahoo/{normal,with_paypay_points}.eml` を合成。
 - `tests/fixtures/mail/yahoo/expected.json` に期待値。
-- `tests/unit/adapters/mail/test_yahoo.py`：
+- `worker/tests/unit/adapters/mail/test_yahoo.py`：
   - ポイントなし: `raw_payload["paypay_points_used"] == "0"`
   - ポイントあり: `raw_payload["paypay_points_used"] == "<利用額>"`
   - 同一メール 2 回でハッシュ一致
@@ -94,9 +94,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/adapters/mail/test_yahoo.py
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/adapters/mail/test_yahoo.py
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -117,7 +117,7 @@ Phase 2.6 Yahoo!ショッピング 注文確認メールパーサを実装。
 - worker/src/kakeibo_worker/adapters/mail/yahoo.py
 - tests/fixtures/mail/yahoo/{normal,with_paypay_points}.eml
 - tests/fixtures/mail/yahoo/expected.json
-- tests/unit/adapters/mail/test_yahoo.py
+- worker/tests/unit/adapters/mail/test_yahoo.py
 
 ## 検証結果
 - 全件緑（2 パターン）

--- a/worker/docs/plans/Ph2/07-adapter-paypal-api.md
+++ b/worker/docs/plans/Ph2/07-adapter-paypal-api.md
@@ -50,7 +50,7 @@ last_updated: 2026-05-01
 | `worker/src/kakeibo_worker/adapters/_http.py` | 指数バックオフ付き HTTP クライアントヘルパ（PayPal 専用 or 汎用） |
 | `tests/fixtures/paypal/sample_transaction_response.json` | PayPal API レスポンスの fixture |
 | `tests/fixtures/paypal/rate_limit_response.json` | HTTP 429 レスポンス fixture |
-| `tests/unit/adapters/test_paypal.py` | API モック + レート制限リトライ + 冪等性 |
+| `worker/tests/unit/adapters/test_paypal.py` | API モック + レート制限リトライ + 冪等性 |
 
 ## 実装方針
 
@@ -78,7 +78,7 @@ last_updated: 2026-05-01
 
 - `tests/fixtures/paypal/sample_transaction_response.json` を Sandbox の実フォーマットに合わせて合成（実取引情報は禁止）。
 - `tests/fixtures/paypal/rate_limit_response.json` で HTTP 429 + `Retry-After: 1` 形式。
-- `tests/unit/adapters/test_paypal.py`：
+- `worker/tests/unit/adapters/test_paypal.py`：
   - 正常系: モック HTTP で 200 → `Transaction` リスト返却
   - レート制限: 1 回目 429 → 2 回目 200、ハンドリングが期待通り（スリープモック）
   - レート制限が 4 回連続で `AdapterError`
@@ -108,9 +108,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/adapters/test_paypal.py
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/adapters/test_paypal.py
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -133,7 +133,7 @@ Phase 2.7 PayPal Transactions API クライアントを実装。
 - worker/src/kakeibo_worker/adapters/paypal.py
 - worker/src/kakeibo_worker/adapters/_http.py
 - tests/fixtures/paypal/{sample_transaction_response,rate_limit_response}.json
-- tests/unit/adapters/test_paypal.py
+- worker/tests/unit/adapters/test_paypal.py
 
 ## 検証結果
 - 全件緑（モック含む）

--- a/worker/docs/plans/Ph2/08-cron-batch-runner.md
+++ b/worker/docs/plans/Ph2/08-cron-batch-runner.md
@@ -50,10 +50,10 @@ last_updated: 2026-05-01
 | `worker/src/kakeibo_worker/jobs/gmail_ingest.py` | Gmail 取込ジョブ（Amazon / 楽天 / Yahoo を順に実行） |
 | `worker/src/kakeibo_worker/jobs/paypal_ingest.py` | PayPal 取込ジョブ |
 | `worker/src/kakeibo_worker/main.py` | `run()` の中で Scheduler を起動（既存 API 互換維持） |
-| `tests/unit/worker/test_scheduler.py` | ジョブ登録 / トリガ時刻 / 実行ログ |
-| `tests/unit/worker/test_gmail_ingest_job.py` | Gmail ジョブが冪等に動く |
-| `tests/unit/worker/test_paypal_ingest_job.py` | PayPal ジョブが冪等に動く |
-| `tests/integration/scheduler/test_scheduler_e2e.py` | 短い間隔でジョブを発火させて DB 反映を確認 |
+| `worker/tests/unit/worker/test_scheduler.py` | ジョブ登録 / トリガ時刻 / 実行ログ |
+| `worker/tests/unit/worker/test_gmail_ingest_job.py` | Gmail ジョブが冪等に動く |
+| `worker/tests/unit/worker/test_paypal_ingest_job.py` | PayPal ジョブが冪等に動く |
+| `worker/tests/integration/scheduler/test_scheduler_e2e.py` | 短い間隔でジョブを発火させて DB 反映を確認 |
 
 ## 実装方針
 
@@ -71,15 +71,15 @@ last_updated: 2026-05-01
 
 ### 1. Red
 
-- `tests/unit/worker/test_scheduler.py`：
+- `worker/tests/unit/worker/test_scheduler.py`：
   - `register_jobs(scheduler)` が 2 ジョブ登録（gmail / paypal）
   - `CronTrigger` の時刻が期待通り
   - SIGTERM 相当で graceful shutdown
-- `tests/unit/worker/test_gmail_ingest_job.py`：
+- `worker/tests/unit/worker/test_gmail_ingest_job.py`：
   - モック Gmail クライアント + モック persister で `gmail_ingest_job()` が Amazon / 楽天 / Yahoo の順に呼ばれる
   - 連続 2 回実行で永続化呼び出し回数は同じだが行数増加なし（モック persister の `ON CONFLICT` 模倣）
-- `tests/unit/worker/test_paypal_ingest_job.py`：同様に PayPal 単独。
-- `tests/integration/scheduler/test_scheduler_e2e.py`：testcontainers Postgres + 短い `next_run_time` で実発火 → DB 反映確認。
+- `worker/tests/unit/worker/test_paypal_ingest_job.py`：同様に PayPal 単独。
+- `worker/tests/integration/scheduler/test_scheduler_e2e.py`：testcontainers Postgres + 短い `next_run_time` で実発火 → DB 反映確認。
 
 ### 2. Green
 
@@ -105,9 +105,9 @@ last_updated: 2026-05-01
 ## 品質ゲート
 
 ```bash
-pytest tests/unit/worker/ tests/integration/scheduler/
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/worker/ worker/tests/integration/scheduler/
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 ## ブランチ・コミット規約
@@ -131,8 +131,8 @@ Phase 2.8 cron バッチ運用化を実装。
 - worker/src/kakeibo_worker/scheduler.py
 - worker/src/kakeibo_worker/jobs/{gmail_ingest,paypal_ingest}.py
 - worker/src/kakeibo_worker/main.py（拡張）
-- tests/unit/worker/{test_scheduler,test_gmail_ingest_job,test_paypal_ingest_job}.py
-- tests/integration/scheduler/test_scheduler_e2e.py
+- worker/tests/unit/worker/{test_scheduler,test_gmail_ingest_job,test_paypal_ingest_job}.py
+- worker/tests/integration/scheduler/test_scheduler_e2e.py
 
 ## 検証結果
 - 全件緑（unit + integration）

--- a/worker/docs/plans/Ph2/README.md
+++ b/worker/docs/plans/Ph2/README.md
@@ -21,8 +21,8 @@ last_updated: 2026-05-01
 | メールパーサ群（Amazon / 楽天 / Yahoo） | `worker/src/kakeibo_worker/adapters/mail/{amazon,rakuten,yahoo}.py` |
 | PayPal API クライアント | `worker/src/kakeibo_worker/adapters/paypal.py` |
 | cron バッチランナー / scheduler | `worker/src/kakeibo_worker/scheduler.py`, `worker/Dockerfile`（cron 関連改修） |
-| Phase2 統合テスト | `tests/integration/{watcher,archiver,mail,paypal,scheduler}/` |
-| メール fixture（合成 .eml） | `tests/fixtures/mail/{amazon,rakuten,yahoo}/*.eml` |
+| Phase2 統合テスト | `worker/tests/integration/{watcher,archiver,mail,paypal,scheduler}/` |
+| メール fixture（合成 .eml） | `tests/fixtures/mail/{amazon,rakuten,yahoo}/*.eml`（横断 fixture） |
 
 ### このディレクトリでは扱わないもの
 
@@ -66,7 +66,7 @@ worker/Ph2/07 (PayPal)
 
 ## 共通の前提
 
-- **Phase1 完了が必須**（`worker/Ph1/01〜07` と `postgres/Ph1/01` が緑）
+- **Phase1 完了が必須**（`worker/docs/plans/Ph1/04〜08` と `postgres/docs/plans/Ph1/02-03` が緑）
 - `pyproject.toml` の dependencies / dev / mail extras は宣言済み（追加は最小限）
 - secrets ファイルは `secrets/*.example` を参考にローカル開発用にコピーして使用（実値は git に絶対コミットしない）
 - `compose.yml` の `worker` 環境変数（`INBOX_PATH`, `GMAIL_OAUTH_TOKEN_FILE` など）は変更不要（既宣言）
@@ -87,9 +87,9 @@ worker/Ph2/07 (PayPal)
 ## 共通の品質ゲート
 
 ```bash
-pytest tests/unit/ tests/integration/   # 該当範囲緑（統合は 5 分以内）
-ruff check .
-pyright
+docker compose run --rm worker pytest worker/tests/unit/ worker/tests/integration/   # 該当範囲緑（統合は 5 分以内）
+docker compose run --rm worker ruff check .
+docker compose run --rm worker pyright
 ```
 
 統合確認（`08-cron-batch-runner.md` 完了後）：

--- a/worker/docs/plans/Ph3/README.md
+++ b/worker/docs/plans/Ph3/README.md
@@ -32,7 +32,7 @@ last_updated: 2026-05-01
 |---|---|---|
 | `pyproject.toml` `[project.dependencies]` への追加（`flask-smorest`, `marshmallow`） | 可（再ビルド必要） | `api/Ph3/01` で発生。worker イメージにも反映されるが起動時は import されない |
 | `shared/kakeibo_shared/__init__.py` の `__version__` 更新 | 可 | リリース時の同期 |
-| `shared/kakeibo_shared/config.py` への認証バイパスフラグ追加 | 慎重に | `api/Ph3/01` で `KAKEIBO_API_AUTH_BYPASS` を Settings に追加する際、worker では参照しないが既存テスト（`tests/unit/test_settings_repr.py`）を壊さないこと |
+| `shared/kakeibo_shared/config.py` への認証バイパスフラグ追加 | 慎重に | `api/Ph3/01` で `KAKEIBO_API_AUTH_BYPASS` を Settings に追加する際、worker では参照しないが既存テスト（`worker/tests/unit/test_settings_repr.py`）を壊さないこと |
 | `worker/Dockerfile` 変更 | 不要 | – |
 
 `agent-rules/00-core-principles.md` の3原則 §1 デグレッション防止と整合：既存の取込パイプラインの動作・既存テストを壊さないこと。
@@ -41,7 +41,7 @@ last_updated: 2026-05-01
 
 Phase 4 で本サービスに変更が必要となる候補：
 
-- **Phase 4.1 LLM 分類サービス**: `api/Ph3/03` で実装される `src/kakeibo/categorizer/rules.py` を再利用しつつ、未マッチ取引を Anthropic API に投げて分類するワーカージョブを `worker/src/kakeibo_worker/jobs/llm_classify.py` として追加
+- **Phase 4.1 LLM 分類サービス**: `api/Ph3/03` で実装される `api/src/kakeibo_api/categorizer/rules.py` を再利用しつつ、未マッチ取引を Anthropic API に投げて分類するワーカージョブを `worker/src/kakeibo_worker/jobs/llm_classify.py` として追加
 - **Phase 4.2 半自動学習**: ルール提案ジョブを `worker/src/kakeibo_worker/jobs/rule_suggest.py` として追加
 - **Phase 4.3 Reconciler**: 連動取引マージのワーカージョブ
 - **Phase 4.4 残高整合性レポート**: 日次整合性チェックジョブ
@@ -55,7 +55,7 @@ Phase3 期間中の起動は **Reviewer のみ**：
 
 | Worker | 役割 |
 |---|---|
-| Reviewer | `api/Ph3/01` で `pyproject.toml` に `flask-smorest` / `marshmallow` が追加されたとき、`worker` コンテナのビルド・起動・既存テスト（`tests/unit/`, `tests/integration/`）が壊れないことを Read のみで確認 |
-| Reviewer | `api/Ph3/03` で実装される `src/kakeibo/categorizer/rules.py` が、Phase 4.1 LLM 分類との接合点として再利用しやすい設計か（責務分離・依存方向）を確認 |
+| Reviewer | `api/Ph3/01` で `pyproject.toml` に `flask-smorest` / `marshmallow` が追加されたとき、`worker` コンテナのビルド・起動・既存テスト（`worker/tests/unit/`, `worker/tests/integration/`）が壊れないことを Read のみで確認 |
+| Reviewer | `api/Ph3/03` で実装される `api/src/kakeibo_api/categorizer/rules.py` が、Phase 4.1 LLM 分類との接合点として再利用しやすい設計か（責務分離・依存方向）を確認 |
 
 Coder / Planner / Git-composer の起動は Phase3 では原則不要。

--- a/worker/docs/plans/README.md
+++ b/worker/docs/plans/README.md
@@ -18,7 +18,7 @@ last_updated: 2026-05-01
 | 取込アダプタ抽象基底 | `worker/src/kakeibo_worker/adapters/base.py`, `errors.py` |
 | MUFG / SMBC CSV 機関別アダプタ | `worker/src/kakeibo_worker/adapters/mufg.py`, `smbc.py` |
 | 取込 CLI（`python -m kakeibo_worker.ingest`） | `worker/src/kakeibo_worker/ingest/cli.py`, `registry.py`, `persister.py` |
-| 取込パイプライン全般のユニットテスト | `worker/tests/unit/{domain,adapters,ingest}/`（移行先） |
+| 取込パイプライン全般のユニットテスト | `worker/tests/unit/{domain,adapters,ingest}/` |
 | watchdog Watcher / メールパーサ / PayPal API（Phase 2） | `worker/src/kakeibo_worker/` |
 | LLM カテゴリ分類（Phase 4） | `worker/src/kakeibo_worker/categorization/` |
 
@@ -82,9 +82,9 @@ worker/Ph1/04 ┬─→ worker/Ph1/05 ┐
 各タスク完了時：
 
 ```bash
-pytest tests/                        # 該当範囲が全件緑
-ruff check .                         # 違反ゼロ
-pyright                              # 警告ゼロ
+docker compose run --rm worker pytest worker/tests/   # 該当範囲が全件緑
+docker compose run --rm worker ruff check .           # 違反ゼロ
+docker compose run --rm worker pyright                # 警告ゼロ
 ```
 
 統合確認（`worker/Ph1/07` 完了後）：


### PR DESCRIPTION
## 目的

ADR-014（per-service source layout）と ADR-015（コンテナ内 Python ツールチェーン）の決定がコード側で完了している一方、`docs/plans/` と `docs/design/` の記述が旧レイアウト（`src/kakeibo/`、`ui/app/`、ホスト venv 前提の `pytest`/`alembic` 直叩き）のまま残っていた。本 PR でドキュメントを実構成に追従させる。GitHub issue #3（Phase 1.2 共通ドメイン型）の本文も同時に更新済み。

## 変更概要

4 アトミックコミット、46 ファイル、コードには触れていない（ドキュメントのみ）。

| Commit | 範囲 | 主な内容 |
|---|---|---|
| 7b86c06 | `docs/plans/{00,01,12,13}` | 横断俯瞰プランの per-service レイアウト追従。Phase2/3 振り分けのディレクトリツリー・リンクパス、Phase 番号 (`worker/Ph1/05` → `Ph1/07`、`postgres/Ph1/01` → `Ph1/02`)、ADR-015 のホスト要件、開発初期化手順を `docker compose run --rm worker ...` に書き換え |
| 37a976e | `ui/docs/plans/**` (8 files) | UI プラン参照パスを `ui/app/` から実配置の `ui/src/app/` に一括追従 |
| b401721 | `api/`, `worker/`, `postgres/` の docs/plans (26 files) | テスト配置を per-service `<service>/tests/...` に、`src/kakeibo/` を `api/src/kakeibo_api/`・`worker/src/kakeibo_worker/`・`shared/kakeibo_shared/` に分割。Categorizer は `api/src/kakeibo_api/categorizer/`、SQL runner は `shared/kakeibo_shared/sql/`。pytest/ruff/pyright を `docker compose run --rm worker ...` 形式に統一 |
| 6f79988 | `docs/design/{00,04}`, `postgres/docs/design/01`, `worker/docs/design/{02,03,06,07,08}` | 設計書のモジュール・ファイルパスを ADR-014 per-service レイアウトに追従。`docker-compose.yml` → `compose.yml`、Alembic 実行を `-c postgres/src/alembic.ini` 付きに、`worker/src/kakeibo_worker/...` への絶対パス化、Categorizer の api 帰属、seeds 配置を `postgres/src/sql/seeds/` に |

## 検証

- 変更後グレップで残骸ゼロを確認:
  - `grep -rn "src/kakeibo/" docs/ */docs/` → 0 件（ADR-014/015 本文の歴史記述を除く）
  - `grep -rn "ui/app/" docs/ */docs/` → 0 件
  - `grep -rn "docker-compose\.yml\|docker-compose-dev" docs/ */docs/` → 0 件
- 4 コミットすべて 1 論理変更で構成、Co-Author / メタデータ無し（agent-rules/10-git-strategy.md 準拠）

## Test plan

- [x] レビュアが各 commit を順に確認し、commit メッセージと変更内容が一致することを目視確認
- [x] `docs/plans/12-phase2-service-assignments.md` / `13-phase3-service-assignments.md` のディレクトリツリーが実 `<service>/docs/plans/PhN/` と一致することを確認
- [x] `gh issue view 3` で Phase 1.2 issue の本文が新パスに更新されていることを確認
- [x] Phase 1.2 着手時に `feature/domain-types` ブランチで本 PR の最新指示書（`postgres/docs/plans/Ph1/03-domain-types.md`）に従って実装が進められることを確認

## 関連

- 親 ADR: docs/adr/014-per-service-source-layout.md, docs/adr/015-container-local-python-toolchain.md
- 関連 issue: #3（Phase 1.2 共通ドメイン型）— 本文も同時更新済み