### PR TITLE
alembic CLI 本番手順疎通修正と DeprecationWarning 解消

### DIFF
--- a/postgres/src/alembic.ini
+++ b/postgres/src/alembic.ini
@@ -8,7 +8,12 @@
 # - テストで env.py を直接 import して URL 解決ロジックを検証できる
 
 [alembic]
-script_location = alembic
+# script_location は ``%(here)s`` (alembic.ini 自身のディレクトリ) を起点に
+# 解決する。CWD 相対 (``alembic``) だと WORKDIR=/app の本番手順
+# ``alembic -c /app/postgres/src/alembic.ini upgrade head`` で
+# /app/alembic を探してしまい ``Path doesn't exist: alembic.`` で失敗する。
+# 絶対パス化により、どの CWD で呼ばれても /app/postgres/src/alembic を解決できる。
+script_location = %(here)s/alembic
 prepend_sys_path = .
 version_path_separator = os
 sqlalchemy.url = ${DATABASE_URL}

--- a/postgres/src/alembic.ini
+++ b/postgres/src/alembic.ini
@@ -15,6 +15,10 @@
 # 絶対パス化により、どの CWD で呼ばれても /app/postgres/src/alembic を解決できる。
 script_location = %(here)s/alembic
 prepend_sys_path = .
+# alembic 1.13+ で path_separator が必須化された (未指定で DeprecationWarning)。
+# ``os`` は OS 依存のセパレータ (POSIX=":", Windows=";") を使う既定値。
+# version_path_separator (versions ディレクトリ内のリビジョン分離) とは別概念。
+path_separator = os
 version_path_separator = os
 sqlalchemy.url = ${DATABASE_URL}
 

--- a/postgres/tests/unit/db/conftest.py
+++ b/postgres/tests/unit/db/conftest.py
@@ -13,11 +13,9 @@
 - DB アクセスは ``psycopg`` を直接使う。SQLAlchemy 例外ラップを介さないため、
   ``psycopg.errors.UniqueViolation`` 等の具体例外型を ``pytest.raises`` で素直に
   捕捉できる（planner レポート §4.2 と整合）。
-- alembic.ini の ``script_location = alembic`` は CWD 相対で解決されるため、
-  pytest 実行時 CWD（``/app/shared`` 想定）からは見つからない。テスト用に
-  ``Config.set_main_option("script_location", ...)`` で絶対パスへ上書きし、
-  本番運用（worker コンテナ内 ``cd /app/postgres/src && alembic upgrade head``）の
-  挙動を一切変えない方針を採る（agent-rules/00-core-principles.md デグレ防止）。
+- alembic.ini の ``script_location`` は ``%(here)s/alembic`` で ini ファイル基準に
+  解決されるため、CWD に依存せず ``Config(str(ini_path))`` の素直な呼び出しで
+  本番手順と同じ挙動になる（テスト用 workaround は不要）。
 """
 
 from __future__ import annotations
@@ -31,7 +29,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from alembic.config import Config
     import psycopg
     from testcontainers.postgres import PostgresContainer
 
@@ -49,28 +46,6 @@ def _repo_root() -> Path:
     独立させる。
     """
     return Path(__file__).resolve().parents[4]
-
-
-def make_alembic_config(repo_root: Path) -> Config:
-    """テスト用に alembic Config を組み立てる共通ヘルパ。
-
-    ``alembic.ini`` の ``script_location = alembic`` は CWD 相対で解釈されるため、
-    pytest 実行 CWD（shared/）からは ``alembic`` ディレクトリが見えず
-    ``CommandError: Path doesn't exist: alembic`` で失敗する。本ヘルパでは
-    ``script_location`` を ``postgres/src/alembic`` の絶対パスへ上書きし、
-    どの CWD で呼ばれても確実に解決できるようにする。
-
-    本番運用（``cd /app/postgres/src && alembic upgrade head``）には影響しない。
-    """
-    from alembic.config import Config
-
-    ini_path = repo_root / "postgres" / "src" / "alembic.ini"
-    config = Config(str(ini_path))
-    config.set_main_option(
-        "script_location",
-        str(repo_root / "postgres" / "src" / "alembic"),
-    )
-    return config
 
 
 @pytest.fixture(scope="session")
@@ -106,6 +81,7 @@ def applied_database(postgres_container: PostgresContainer) -> str:
         psycopg 接続用の DSN（``postgresql://`` 形式、SQLAlchemy ドライバ接頭辞なし）。
     """
     from alembic import command
+    from alembic.config import Config
 
     sqlalchemy_url = postgres_container.get_connection_url()
     psycopg_dsn = postgres_container.get_connection_url(driver=None)
@@ -114,7 +90,10 @@ def applied_database(postgres_container: PostgresContainer) -> str:
     # session 終了で破棄されるため、復元処理は不要。
     os.environ["DATABASE_URL"] = sqlalchemy_url
 
-    config = make_alembic_config(_repo_root())
+    # alembic.ini の script_location は %(here)s/alembic (ini ファイル基準) なので、
+    # CWD に関わらず Config(str(ini_path)) のみで正しく解決される。
+    ini_path = _repo_root() / "postgres" / "src" / "alembic.ini"
+    config = Config(str(ini_path))
     command.upgrade(config, "head")
 
     return psycopg_dsn

--- a/postgres/tests/unit/db/test_migration_idempotency.py
+++ b/postgres/tests/unit/db/test_migration_idempotency.py
@@ -20,28 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from alembic.config import Config
-
     import psycopg
-
-
-def _make_alembic_config(repo_root: Path) -> Config:
-    """テスト用に alembic Config を組み立てる小ヘルパ。
-
-    ``alembic.ini`` の ``script_location = alembic`` は CWD 相対で解釈される
-    （CWD=shared/ では見つからず CommandError）ため、ここで絶対パスに上書きする。
-    conftest.make_alembic_config と同等の振る舞いだが、テストファイルから
-    隣接 conftest.py の関数を直接 import するのを避けるため重複させている。
-    """
-    from alembic.config import Config
-
-    ini_path = repo_root / "postgres" / "src" / "alembic.ini"
-    config = Config(str(ini_path))
-    config.set_main_option(
-        "script_location",
-        str(repo_root / "postgres" / "src" / "alembic"),
-    )
-    return config
 
 
 _LATEST_REVISION = "0005"
@@ -73,6 +52,7 @@ def test_2回目のupgrade_headが例外なく成功する(
     本テストは「実装が標準仕様から外れていない」ことを担保する回帰防止テスト。
     """
     from alembic import command
+    from alembic.config import Config
 
     # applied_database フィクスチャで DATABASE_URL は既に設定済みだが、
     # 明示的に検証して契約を固定する。
@@ -80,7 +60,7 @@ def test_2回目のupgrade_headが例外なく成功する(
         "applied_database フィクスチャ後に DATABASE_URL が設定されていません"
     )
 
-    config = _make_alembic_config(repo_root)
+    config = Config(str(repo_root / "postgres" / "src" / "alembic.ini"))
     # ここで例外が出れば pytest が失敗扱いにする。明示の assert は不要。
     command.upgrade(config, "head")
 
@@ -96,8 +76,9 @@ def test_2回目upgrade後のリビジョンが末端と一致する(
     末端リビジョン名が変われば本テストは失敗し、命名規約からの逸脱を検出する。
     """
     from alembic import command
+    from alembic.config import Config
 
-    config = _make_alembic_config(repo_root)
+    config = Config(str(repo_root / "postgres" / "src" / "alembic.ini"))
     command.upgrade(config, "head")
 
     with psycopg_connection.cursor() as cur:
@@ -123,10 +104,11 @@ def test_2回目upgrade前後でテーブル数が一致する(
     spec §テスト計画3「テーブル数が変化しない」を直接固定する。
     """
     from alembic import command
+    from alembic.config import Config
 
     before = _count_public_tables(psycopg_connection)
 
-    config = _make_alembic_config(repo_root)
+    config = Config(str(repo_root / "postgres" / "src" / "alembic.ini"))
     command.upgrade(config, "head")
 
     # 別接続でカウントを取り直す（カタログ更新の即時反映確認）。


### PR DESCRIPTION
## 背景

PR #12（DBスキーマ資産の per-service 移送）のレビュー過程で、3 件の独立した既存バグが顕在化した。本 PR はそれらをまとめて解消する。

## 修正内容

### バグ 1: 本番 alembic CLI 不動作
README.md / docs/design/04-deployment-stack.md に記載の
```
docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini upgrade head
```
が `script_location = alembic`（CWD 相対）の解釈問題で `Path doesn't exist: alembic.` と失敗していた。`script_location = %(here)s/alembic` に変更し ini ファイル基準で絶対解決するよう修正。

### バグ 2: alembic DeprecationWarning
alembic 1.13+ で必須化された `path_separator` を `os` で追加。pytest 実行時の 4 件の DeprecationWarning が消滅。

### バグ 3: テストヘルパ重複削除
バグ 1 の workaround として PR #12 で `make_alembic_config()` ヘルパを 2 ファイルに重複追加していた。バグ 1 解消により workaround が真に不要化したため、ヘルパとその全呼び出しを削除し `Config(str(...))` 直接呼び出しへ戻した。

## テスト計画

- [x] `docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini history` → 成功（5 リビジョン線形表示）
- [x] `docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini heads` → 成功（`0005 (head)`）
- [x] `docker compose run --rm worker pytest -q` → 154 passed（PR #12 と同数維持）
- [x] `docker compose run --rm worker pytest postgres/tests/unit/db -v` → 83 passed
- [x] `docker compose run --rm worker ruff check .` → All checks passed
- [x] `docker compose run --rm worker pyright` → 0 errors
- [x] `make_alembic_config` への参照: grep ゼロ件
- [x] 4 件の DeprecationWarning が解消（pytest 出力で確認）

## 既知の課題（本 PR 範疇外）

`upgrade head` を end-to-end で通すには **psycopg ドライバ未指定問題** の修正が必要。
- `compose.yml` の `DATABASE_URL=postgresql://...`（ドライバ未指定）→ SQLAlchemy が psycopg2 を要求 → `ModuleNotFoundError: No module named 'psycopg2'` で失敗
- 修正方針: `postgresql+psycopg://...` に変更（compose.yml の api/worker 両方、設計ドキュメントの記載例、shared/kakeibo_shared/db/session.py の docstring）
- **別 hotfix ブランチ `hotfix/database-url-driver-prefix` で対応予定**（クリティカル度高、論理的にも script_location 問題と独立）
- 本 PR は alembic CLI が `script_location` を解決して history/heads が動く状態まで達成。upgrade head の本疎通は hotfix 完了後

## 依存関係

- **base ブランチ**: `feature/db-schema-relocate-to-postgres-service`（PR #12）
- PR #12 がマージされた後、本 PR の base を `develop` に切り替える必要あり
- PR #12 を先にマージしないと、本 PR の差分に PR #12 の内容も混入する

## 関連

- PR #12（DBスキーマ資産 per-service 移送）
- `postgres/docs/plans/Ph1/02-db-schema-and-migrations.md`