### PR TITLE
DATABASE_URL を postgresql+psycopg:// に統一し psycopg2 ImportError を解消

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # パスワードは PG_PASSWORD_FILE 経由で渡すことを原則とするため、
 # URL にはユーザ名のみ書き、パスワードは PG_PASSWORD_FILE から注入する。
 # ローカル開発の利便性のためにパスワードを URL に含める運用も可。
-DATABASE_URL=postgresql://kakeibo:devpassword@localhost:5432/kakeibo
+DATABASE_URL=postgresql+psycopg://kakeibo:devpassword@localhost:5432/kakeibo
 
 # ── Docker secret ファイルパス（FILE 規約） ──
 # 開発時は secrets/<name>.txt を直接参照する。

--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
       # 上書き読込（同パス）を許容する設計。
       - ./shared:/app/shared:ro
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       PG_PASSWORD_FILE: /run/secrets/pg_password
       ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_key
       TZ: Asia/Tokyo
@@ -82,7 +82,7 @@ services:
       - ./postgres/src/alembic:/app/postgres/src/alembic:ro
       - ./postgres/src/alembic.ini:/app/postgres/src/alembic.ini:ro
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       PG_PASSWORD_FILE: /run/secrets/pg_password
       ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_key
       PAYPAL_API_SECRET_FILE: /run/secrets/paypal_api_secret

--- a/docs/adr/016-database-password-injection-strategy.md
+++ b/docs/adr/016-database-password-injection-strategy.md
@@ -1,0 +1,186 @@
+---
+adr: 016
+title: PostgreSQL パスワードを SQLAlchemy URL.set でランタイム注入する
+status: 採用済み
+date: 2026-05-02
+author: 池田遼介
+related:
+  - ADR-011
+  - ADR-014
+  - ADR-015
+extends:
+  - ADR-011
+---
+
+# ADR-016: PostgreSQL パスワードを SQLAlchemy URL.set でランタイム注入する
+
+## ステータス
+採用済み
+
+## 背景
+
+PR #14 で `compose.yml` の `DATABASE_URL` を以下の形式に統一した:
+
+```
+postgresql+psycopg://kakeibo@postgres:5432/kakeibo
+```
+
+パスワードを URL から完全に除外し、機密値は Docker secret（`/run/secrets/pg_password`）として `PG_PASSWORD_FILE` 経由で配信する設計に揃えた。これは ADR-011（認証情報非保持の発展形として、機密値はマウントされた secret ファイルからのみ供給する）に整合する。
+
+しかしこの変更後、`alembic upgrade head` を実行すると以下で失敗する:
+
+```
+psycopg.OperationalError: connection failed: fe_sendauth: no password supplied
+```
+
+`DATABASE_URL` がパスワード抜きで宣言されているため、SQLAlchemy はそのまま psycopg3 ドライバへ渡し、psycopg3 が `password` パラメータ無しの接続要求を組み立て、PostgreSQL は `28P01` 相当を返す。`Settings.pg_password` は `_resolve_secret_file()` 経由で正しく `super-secret-pw` のような値を保持しているが、誰もそれを URL に合流させていなかった。
+
+`shared/kakeibo_shared/db/session.py::create_db_engine` および `postgres/src/alembic/env.py::run_migrations_online` の双方で、`settings.pg_password` を URL に注入する経路が未実装である。本 ADR でその注入方式を定める。
+
+## 検討した選択肢
+
+### 選択肢A. compose.yml の `DATABASE_URL` に再びパスワードを埋め込む
+
+`postgresql+psycopg://kakeibo:${PG_PASSWORD}@postgres:5432/kakeibo` のように、Docker Compose の変数展開で `PG_PASSWORD` 環境変数からパスワードを補間する。
+
+- メリット:
+  - URL を見れば接続情報が完結し、デバッグで「なぜ password 無しなのか」と迷わない
+  - 実装変更が compose.yml のみで済む
+- デメリット:
+  - PR #14 の主旨（URL に機密を埋めない）を真っ向から覆す
+  - `docker compose config` の出力に password が平文で出てしまい、`docker inspect` でも環境変数として露出する
+  - `secrets:` 機構（メモリのみ展開、ログに出ない）を使う意義が希薄化する
+  - `ANTHROPIC_API_KEY` 等の他 secret と取り扱いがチグハグになる
+
+### 選択肢B. ドライバ依存の `connect_args` でパスワードを渡す
+
+`create_engine(url, connect_args={"password": settings.pg_password})` で psycopg3 接続時に直接 password を注入する。
+
+- メリット:
+  - URL は触らずに接続層だけで完結
+  - 実装シンプル
+- デメリット:
+  - `connect_args` のキーはドライバ固有（psycopg3 / psycopg2 / asyncpg で名前が異なる）。将来 driver を切り替えるたびに見直しが要る
+  - `engine.url` 属性には password が含まれないため、SQLAlchemy 標準の `URL.__repr__` マスク（`***`）の二重防壁が機能しない（password は `connect_args` 辞書側にあり、辞書 repr は値を出してしまう）
+  - alembic との橋渡しで重複実装になる（env.py 側でも同じ `connect_args` 構築が必要）
+
+### 選択肢C. SQLAlchemy `URL.set(password=...)` でランタイムに URL を再構築（採用）
+
+`make_url(settings.database_url).set(password=settings.pg_password)` で、ランタイムに password を合流させた `URL` オブジェクトを構築し、それを `create_engine` に渡す。`build_database_url(settings) -> URL` という小さなヘルパに切り出し、`create_db_engine` と alembic env.py の双方が経由する。
+
+- メリット:
+  - 機密は compose.yml に出さない（PR #14 の主旨を維持）
+  - `URL.set` は SQLAlchemy 公式の immutable URL 操作 API で、ドライバ非依存
+  - `URL.__repr__` が password を `***` にマスクするため、SQLAlchemy が出すあらゆる例外メッセージ・ログで自動マスクが効く（`Settings.__repr__` のマスクと併せて二重防壁）
+  - alembic env.py から `Settings` を直接 import できるため、worker / api / alembic の 3 経路すべてで同じ URL 組み立てロジックを共有できる
+- デメリット:
+  - `Settings()` の二回インスタンス化（runtime と env.py 両方で行う）が発生するが、pydantic-settings の env-var パースは軽量で問題にならない
+  - `URL` オブジェクトを返す関数を新設するため、既存の「URL は文字列」前提のコードを少しだけ更新する必要がある（`resolve_database_url()` は後方互換のため文字列返却で残置）
+
+### 選択肢D. compose.yml の `environment` で `command` ラッパーを書き、起動前に secret を読んで `DATABASE_URL` を再エクスポート
+
+`command: sh -c 'export DATABASE_URL="postgresql+psycopg://kakeibo:$(cat /run/secrets/pg_password)@postgres:5432/kakeibo"; exec ...'`
+
+- メリット:
+  - アプリ側コード変更ゼロ
+- デメリット:
+  - 各サービスのエントリポイントを書き換える必要があり、Dockerfile の `CMD` と二重管理になる
+  - `ps -ef` でプロセスの ARGV を見ると展開後の URL が露出する
+  - コマンドラインに password が入るため、コンテナ内のサイドカープロセスからも見える
+
+## 決定
+
+**選択肢 C を採用する。**
+
+`shared/kakeibo_shared/db/session.py` に以下のヘルパを追加し、`create_db_engine` と alembic `env.py::run_migrations_online` の双方が経由する:
+
+```python
+def build_database_url(settings: Settings) -> URL:
+    url = make_url(settings.database_url)
+    if url.password is not None:
+        return url                         # 開発 .env で URL に埋め込み済み → 尊重
+    if settings.pg_password:
+        return url.set(password=settings.pg_password)
+    return url                             # fail-open: 28P01 で診断容易
+```
+
+優先順は以下の通り:
+
+1. `DATABASE_URL` に既に password が含まれていればそれを使用
+   （開発 `.env` の `kakeibo:devpassword@...` 運用を保全）
+2. それ以外は `settings.pg_password` を `URL.set` で注入
+3. どちらも無い場合は `password=None` のまま返す（fail-open）
+   → 接続時に DB が `28P01` を返すため診断は容易
+
+### オフラインモード（`alembic upgrade --sql`）の扱い
+
+オフラインモードは SQL スクリプトを生成するだけで実 DB に接続しないため、Docker secret 経由のパスワード注入は不要。本 ADR では防御的設計として、オフラインモードでは `resolve_database_url()` の戻り値（password 抜きの URL 文字列）をそのまま使用し、`build_database_url` 経路（`URL` オブジェクト）は通さない。これにより、生成される SQL スクリプトの URL 表記に password が一切含まれないことを構造的に保証する。
+
+## 理由
+
+- **PR #14 の主旨を維持**: `DATABASE_URL` は引き続きパスワード抜きで宣言され、Docker secret が唯一のパスワード供給経路となる。`docker compose config` / `docker inspect` の出力にも機密が出ない
+- **二重防壁による secret 漏洩防止**: `URL.__repr__` の `***` マスクが SQLAlchemy が送出するあらゆる例外メッセージ・ログで自動的に効く。`Settings.__repr__` のマスク（`[REDACTED]`）と併せて二重防壁となる。`connect_args` 案ではこの自動マスクが機能しない
+- **後方互換性の保全**: 開発 `.env` で `DATABASE_URL=postgresql+psycopg://kakeibo:devpassword@localhost:5432/kakeibo` のようにパスワード埋め込み URL を使う運用は、優先順 1 により完全に保たれる
+- **fail-open 設計の明示**: secret も URL も供給されない場合、隠蔽せず DB の `28P01` をそのまま見せることで、診断時の混乱を避ける（「secret ファイルが空だったのか、URL が壊れていたのか」が DB 側のエラーから明確になる）
+- **3 経路の単一化**: worker / api / alembic がすべて同じ `build_database_url` を経由することで、URL 組み立てロジックの重複・乖離を構造的に防ぐ
+- **ドライバ非依存**: `URL.set` は SQLAlchemy の標準 API のため、将来 psycopg3 → asyncpg 等への切替時にも変更不要
+
+## 結果
+
+### 実装変更
+
+- `shared/kakeibo_shared/db/session.py`:
+  - `build_database_url(settings: Settings) -> URL` を新設
+  - `create_db_engine` を `build_database_url` 経由へ移行
+  - `__all__` に `build_database_url` を追加
+- `postgres/src/alembic/env.py`:
+  - `run_migrations_online()` を `build_database_url` 経由へ移行
+  - `resolve_database_url()` は文字列レベルの環境変数解決として残置（`run_migrations_offline()` 用 + 既存契約テスト `worker/tests/test_environment.py:119` の保全）
+  - docstring に「実 engine 構築には `build_database_url` を使う」旨を追記
+
+### テスト追加
+
+`worker/tests/unit/test_db_url_injection.py` に 5 件の契約テスト:
+
+1. `test_build_database_urlがpg_passwordをURLに注入する` — Docker secret 経由パスワードが `URL.password` に設定される
+2. `test_build_database_urlはURL内のpasswordを優先する` — URL 内 password が `pg_password` より優先される（後方互換）
+3. `test_build_database_urlはpg_password未設定時にURLをそのまま返す` — fail-open 動作
+4. `test_build_database_url結果のreprがpasswordをマスクする` — `URL.__repr__` の `***` マスク動作の固定
+5. `test_build_database_urlは空文字列passwordを意図的指定として尊重する` — `:@` 空文字列 password を意図的指定として尊重する契約の固定（`local trust` 構成への運用余地）
+
+### 検証
+
+- `docker compose run --rm worker pytest -q` → 159 passed（既存 154 + 新規 5）
+- `docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini upgrade head` → `fe_sendauth: no password supplied` エラー解消、`0001 → 0005` まで適用成功
+- `docker compose logs` 内に `pg_password.txt` の secret 値が出現しないことを確認
+
+### URL.__repr__ による password マスクの実機検証（二重防壁の根拠）
+
+`SQLAlchemy URL` の各 string conversion 経路で password が `***` にマスクされることを確認した:
+
+| 経路 | 結果 |
+|---|---|
+| `repr(url)` | `postgresql+psycopg://kakeibo:***@postgres:5432/kakeibo` |
+| `str(url)` | `postgresql+psycopg://kakeibo:***@postgres:5432/kakeibo` |
+| f-string `f"{url}"` | 同上 |
+| `"{}".format(url)` | 同上 |
+| `url.render_as_string()` | 同上 |
+| `url.render_as_string(hide_password=False)` | 平文（明示時のみ） |
+
+加えて、誤った password で `engine.connect()` を試行した際の `OperationalError` スタックトレースに password が露出しないことも実機確認済み。`alembic upgrade head --sql` の出力 SQL にも password の混入なし。
+
+これにより、`Settings.__repr__` のキーワードベース `[REDACTED]` 化（`shared/kakeibo_shared/config.py:139-152`）と合わせて二重防壁が成立している。
+
+### 運用への影響
+
+- `compose.yml` の変更は不要（既に PR #14 でパスワード抜き URL に統一済み）
+- 開発者が `.env` で password 埋め込み URL を使っていても引き続き動作する
+- `secrets/pg_password.txt` を空にすると（あるいは `PG_PASSWORD_FILE` を未設定にすると）、起動時ではなく **DB 接続試行時** に `28P01` が出る。これは fail-open 設計による意図された挙動
+
+## 今後の検討
+
+- **`pg_password` の `SecretStr` 化**: 現在は `str | None` 型のため、`Settings.__repr__` のキーワードベースマスクに依存している。pydantic の `SecretStr` 型に切り替えれば、`__repr__` 自動マスクが型レベルで保証される。ただし `URL.set(password=...)` 呼出時に `.get_secret_value()` が必要となるため、影響範囲を確認した上で別 ADR で検討する
+- **testcontainers 経路の `build_database_url` 統一**: 現状 `postgres/tests/unit/db/conftest.py::applied_database` は testcontainers の `get_connection_url()`（既に password 込み URL）を直接 `os.environ["DATABASE_URL"]` に流し込んでいる。本 ADR の優先順 1（URL 内 password 優先）により従来通り動作するが、運用経路と完全一致させるなら secret ファイルを mock する方式への切り替えも検討価値がある（テスト時間とのトレードオフ）
+- **api コンテナ（Phase 2 以降）**: 現時点では api 配下に DB 接続コードはまだ無いが、追加時には必ず `create_db_engine(settings)` 経由とし、独自に `create_engine(settings.database_url, ...)` を呼ばないようコードレビューで担保する
+- **本 ADR は ADR-011（認証情報非保持）の延長**: 「保持しない」原則の補完として「保持する場合は secret 経由のみ、URL 文字列には現れない」という追加制約をコードレベルで保証する位置づけ
+- **Secret rotate 時の運用手順**: 本番 PostgreSQL パスワードをローテートする際、`compose.yml` の `DATABASE_URL` 環境変数に password が紛れ込んでいないことを再確認する手順を運用 README（または将来の `scripts/rotate_pg_password.sh`）に明記する。「URL 内 password が secret より優先される」設計（§決定 優先順 1）の副作用として、rotate 漏れの温床になる可能性があるため

--- a/docs/design/04-deployment-stack.md
+++ b/docs/design/04-deployment-stack.md
@@ -47,7 +47,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_key
       TZ: Asia/Tokyo
     secrets:
@@ -66,7 +66,7 @@ services:
       - ./archive:/archive:rw
       - ./dead_letter:/dead_letter:rw
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       INBOX_PATH: /inbox
       ARCHIVE_PATH: /archive
       DEAD_LETTER_PATH: /dead_letter

--- a/docs/design/05-security-model.md
+++ b/docs/design/05-security-model.md
@@ -69,7 +69,7 @@ related_adrs:
 | PayPal Client ID | Docker secret | Read-only Transactions | 6ヶ月 | PayPal Developer Dashboard で再発行 |
 | PayPal Secret | Docker secret | Read-only Transactions | 6ヶ月 | 同上 |
 | Anthropic API Key | Docker secret | プロジェクト単位 | 6ヶ月 | Anthropic Console から revoke + 新規発行 |
-| PostgreSQL Password | Docker secret | DB アクセス | 12ヶ月 | DBパスワード変更 + secret 更新 |
+| PostgreSQL Password | Docker secret (`/run/secrets/pg_password`, `PG_PASSWORD_FILE` 経由 → `Settings.pg_password` → `build_database_url` で `URL.set(password=...)` 注入。ADR-016) | DB アクセス | 12ヶ月 | DBパスワード変更 + secret 更新 |
 | age 秘密鍵 | NAS外（紙メモ + 物理金庫） | バックアップ復号 | 不変（紛失時のみ再生成） | バックアップを再暗号化 |
 | Tailscale 認証 | 各端末 OS Keychain | tailnet メンバ | デバイス単位で管理 | デバイスを admin console から削除 |
 

--- a/docs/plans/00-initial-design.md
+++ b/docs/plans/00-initial-design.md
@@ -459,7 +459,7 @@ services:
     build: ./api
     depends_on: [postgres]
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_key
     secrets:
       - anthropic_key
@@ -472,7 +472,7 @@ services:
       - ./inbox:/inbox:rw
       - ./archive:/archive:rw
     environment:
-      DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo
+      DATABASE_URL: postgresql+psycopg://kakeibo@postgres:5432/kakeibo
       INBOX_PATH: /inbox
     networks: [internal]
 

--- a/postgres/src/alembic/env.py
+++ b/postgres/src/alembic/env.py
@@ -5,6 +5,10 @@
   を解決する（agent-rules/12-security-guidelines.md §認証情報）
 - ``resolve_database_url()`` をモジュール公開関数として切り出し、
   単体テストで URL 解決ロジックだけを検証可能にする（tests/test_environment.py）
+- 実 engine 構築には ``kakeibo_shared.db.session.build_database_url`` を使い、
+  Docker secret 経由のパスワードを ``URL.set`` で注入する（ADR-016）。
+  ``resolve_database_url()`` は文字列レベルの環境変数解決のみを責務とする
+  後方互換 API として残置する
 - ``alembic.context`` の属性参照（``context.config`` 等）は CLI 実行時に
   Alembic ランタイムが下準備をした後でしか有効でないため、pytest からの
   単純 import で AttributeError にならないよう try/except でガードする
@@ -21,11 +25,15 @@ from alembic import context
 
 
 def resolve_database_url() -> str:
-    """環境変数 ``DATABASE_URL`` から接続文字列を取得する。
+    """環境変数 ``DATABASE_URL`` から接続文字列を取得する（後方互換 API）。
 
     alembic.ini の ``${DATABASE_URL}`` プレースホルダ展開だけでは、
     pytest からテストする際に ConfigParser の補間タイミングが揃わないため、
     本関数を独立させて単体テストの対象とする。
+
+    実際の engine 構築では ``build_database_url`` を経由し、Docker secret 由来の
+    パスワードを ``URL.set`` で注入する（ADR-016）。本関数は文字列レベルの
+    環境変数解決のみを責務とし、worker/tests/test_environment.py の契約を保つ。
     """
     url = os.environ.get("DATABASE_URL")
     if not url:
@@ -42,7 +50,16 @@ target_metadata: Any = None
 
 
 def run_migrations_offline() -> None:
-    """オフラインモード（SQL スクリプト出力）でマイグレーションを実行する。"""
+    """オフラインモード（SQL スクリプト出力）でマイグレーションを実行する。
+
+    オフラインモードは SQL スクリプトを生成するだけで実 DB に接続しないため、
+    Docker secret 経由のパスワード注入は不要。``build_database_url`` が
+    ``URL`` オブジェクトを返すのは ``URL.__repr__`` で password が ``***`` に
+    マスクされる利点を活かすため（接続用途）だが、オフラインモードで生成される
+    SQL スクリプトの URL 表記には password を一切含めない方が安全（防御的設計）。
+    そのため ``resolve_database_url()`` の戻り値（password 抜きの URL 文字列）を
+    そのまま使用し、``build_database_url`` 経路（``URL`` オブジェクト）は通さない。
+    """
     url = resolve_database_url()
     context.configure(
         url=url,
@@ -55,18 +72,23 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    """オンラインモードで実 DB に接続してマイグレーションを実行する。"""
-    # 重い import は CLI 実行時にだけ行う（テストからの import を軽くする）。
-    from sqlalchemy import engine_from_config, pool
+    """オンラインモードで実 DB に接続してマイグレーションを実行する。
 
-    config = context.config
-    ini_section = config.get_section(config.config_ini_section) or {}
-    ini_section["sqlalchemy.url"] = resolve_database_url()
-    connectable = engine_from_config(
-        ini_section,
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    ``build_database_url`` 経由で Settings から ``URL`` を構築することで、
+    ``DATABASE_URL`` がパスワード抜きで宣言されている場合でも
+    ``PG_PASSWORD_FILE`` 経由のパスワードが ``URL.set`` で注入される（ADR-016）。
+    ``alembic.ini`` の ``sqlalchemy.url`` プレースホルダは経由せず、
+    構築済み ``Engine`` を直接 connect する。
+    """
+    # 重い import は CLI 実行時にだけ行う（テストからの import を軽くする）。
+    from sqlalchemy import create_engine, pool
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    settings = Settings()  # pyright: ignore[reportCallIssue]
+    url_obj = build_database_url(settings)
+    connectable = create_engine(url_obj, poolclass=pool.NullPool, future=True)
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():

--- a/shared/kakeibo_shared/db/session.py
+++ b/shared/kakeibo_shared/db/session.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import URL, make_url
 from sqlalchemy.orm import sessionmaker
 
 if TYPE_CHECKING:
@@ -17,6 +18,36 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from kakeibo_shared.config import Settings
+
+
+def build_database_url(settings: Settings) -> URL:
+    """Settings から SQLAlchemy ``URL`` オブジェクトを構築する。
+
+    Docker secret 規約（``PG_PASSWORD_FILE``）で受け取ったパスワードを
+    SQLAlchemy ``URL.set(password=...)`` 経由で URL に注入する。compose.yml の
+    ``DATABASE_URL`` は ``postgresql+psycopg://kakeibo@postgres:5432/kakeibo``
+    のようにパスワード抜きで宣言され、シークレットはランタイムで合流する。
+
+    優先順:
+      1. ``DATABASE_URL`` に既に password が含まれていればそれを使用
+         （開発 ``.env`` で ``kakeibo:devpassword@...`` と書く運用を保全。
+         空文字列 ``:@`` も意図的指定として尊重 ── ``local trust`` 等の
+         パスワード不要 PostgreSQL 構成で運用余地を残す設計判断。
+         SQLAlchemy 仕様で ``url.password`` は ``""`` と ``None`` を区別する）
+      2. それ以外は ``settings.pg_password`` を ``URL.set`` で注入
+      3. どちらも無い場合は ``password=None`` のまま返す（fail-open）
+         → 接続時に DB が ``28P01`` を返すため診断は容易
+
+    ``URL`` オブジェクトを返すことで、create_engine 側のログ・例外メッセージで
+    SQLAlchemy 標準の ``URL.__repr__`` による password マスク（``***``）が効く。
+    ``Settings.__repr__`` のマスクと合わせて二重防壁となる。詳細は ADR-016。
+    """
+    url = make_url(settings.database_url)
+    if url.password is not None:
+        return url
+    if settings.pg_password:
+        return url.set(password=settings.pg_password)
+    return url
 
 
 def create_db_engine(settings: Settings) -> Engine:
@@ -27,8 +58,11 @@ def create_db_engine(settings: Settings) -> Engine:
     解決するため、psycopg2 が未インストールな本リポジトリでは
     ``ModuleNotFoundError: psycopg2`` で失敗する。``+psycopg`` を明示することで
     psycopg3 を選択する（``shared/pyproject.toml`` の依存と整合）。
+
+    URL の組み立て（特に Docker secret 由来のパスワード注入）は
+    ``build_database_url`` に委譲する。詳細は ADR-016。
     """
-    return create_engine(settings.database_url, future=True)
+    return create_engine(build_database_url(settings), future=True)
 
 
 def create_session_factory(engine: Engine) -> sessionmaker[Session]:
@@ -40,4 +74,4 @@ def create_session_factory(engine: Engine) -> sessionmaker[Session]:
     return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 
-__all__ = ["create_db_engine", "create_session_factory"]
+__all__ = ["build_database_url", "create_db_engine", "create_session_factory"]

--- a/shared/kakeibo_shared/db/session.py
+++ b/shared/kakeibo_shared/db/session.py
@@ -22,8 +22,11 @@ if TYPE_CHECKING:
 def create_db_engine(settings: Settings) -> Engine:
     """Settings から SQLAlchemy エンジンを生成する。
 
-    psycopg3 ドライバを使うため URL は ``postgresql+psycopg://`` を推奨するが、
-    ``postgresql://`` でも psycopg2 が無い環境では psycopg3 が暗黙採用される。
+    psycopg3 ドライバを使うため URL は ``postgresql+psycopg://`` を必須とする。
+    ``postgresql://`` 接頭辞は SQLAlchemy 2.x が ``psycopg2`` のエイリアスとして
+    解決するため、psycopg2 が未インストールな本リポジトリでは
+    ``ModuleNotFoundError: psycopg2`` で失敗する。``+psycopg`` を明示することで
+    psycopg3 を選択する（``shared/pyproject.toml`` の依存と整合）。
     """
     return create_engine(settings.database_url, future=True)
 

--- a/worker/tests/test_environment.py
+++ b/worker/tests/test_environment.py
@@ -40,7 +40,7 @@ def test_設定クラスが環境変数からDATABASE_URLを読める(monkeypatc
     Docker Compose の environment 経由で渡される URL を、Settings で
     一貫して読み取れることを確認する。
     """
-    test_url = "postgresql://kakeibo:secret@postgres:5432/kakeibo"
+    test_url = "postgresql+psycopg://kakeibo:secret@postgres:5432/kakeibo"
     monkeypatch.setenv("DATABASE_URL", test_url)
     monkeypatch.delenv("PG_PASSWORD_FILE", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
@@ -62,7 +62,7 @@ def test_DocSecretのFILE規約で値を取得できる(
     secret_file = tmp_path / "pg_password.txt"
     secret_file.write_text("secret_value\n", encoding="utf-8")
 
-    monkeypatch.setenv("DATABASE_URL", "postgresql://x@y:5432/z")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://x@y:5432/z")
     monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
 
     from kakeibo_shared.config import Settings
@@ -125,7 +125,7 @@ def test_alembic_envがDATABASE_URLを参照する(
     ADR-014 によりマイグレーション資産は ``postgres/src/alembic/`` 配下に移動済み。
     env.py を import して `_resolve_database_url()` を直接呼ぶ。
     """
-    test_url = "postgresql://kakeibo:pw@postgres:5432/kakeibo"
+    test_url = "postgresql+psycopg://kakeibo:pw@postgres:5432/kakeibo"
     monkeypatch.setenv("DATABASE_URL", test_url)
 
     # postgres/src/alembic/ ディレクトリを sys.path に追加して env をモジュールとして読む

--- a/worker/tests/unit/test_db_url_injection.py
+++ b/worker/tests/unit/test_db_url_injection.py
@@ -1,0 +1,138 @@
+"""build_database_url のパスワード注入契約テスト。
+
+Docker secret 経由のパスワードを SQLAlchemy URL.set で注入する仕様（ADR-016）の
+振る舞いを契約として固定する。
+
+検証範囲:
+- PG_PASSWORD_FILE 経由のパスワードが URL.password に設定されること
+- DATABASE_URL に password が既に含まれていれば優先（開発 .env 運用の保全）
+- 双方未供給時は URL.password=None のまま（fail-open: 接続時に DB が 28P01 を返す）
+- URL.__repr__ が password を *** にマスク（ログ漏洩防止の二重防壁）
+
+設計準拠:
+- docs/adr/016-database-password-injection-strategy.md
+- agent-rules/12-security-guidelines.md §4
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_build_database_urlがpg_passwordをURLに注入する(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PG_PASSWORD_FILE 経由のパスワードが URL.password に設定されること。"""
+    secret_file = tmp_path / "pg_password.txt"
+    secret_file.write_text("super-secret-pw\n", encoding="utf-8")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://kakeibo@postgres:5432/kakeibo")
+    monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
+    monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("PAYPAL_API_SECRET_FILE", raising=False)
+    monkeypatch.delenv("GMAIL_OAUTH_TOKEN_FILE", raising=False)
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    url = build_database_url(Settings())  # pyright: ignore[reportCallIssue]
+    assert url.password == "super-secret-pw"
+    assert url.username == "kakeibo"
+    assert url.host == "postgres"
+    assert url.database == "kakeibo"
+
+
+def test_build_database_urlはURL内のpasswordを優先する(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """開発 .env で URL に devpassword が含まれている場合、PG_PASSWORD_FILE より優先される。
+
+    開発時の埋込み URL を壊さないことで、本変更の後方互換性を保証する。
+    """
+    secret_file = tmp_path / "pg_password.txt"
+    secret_file.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg://kakeibo:from-url@localhost:5432/kakeibo",
+    )
+    monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
+    monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("PAYPAL_API_SECRET_FILE", raising=False)
+    monkeypatch.delenv("GMAIL_OAUTH_TOKEN_FILE", raising=False)
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    assert build_database_url(Settings()).password == "from-url"  # pyright: ignore[reportCallIssue]
+
+
+def test_build_database_urlはpg_password未設定時にURLをそのまま返す(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """secret 未供給かつ URL も password 無しの場合、URL.password は None のまま（fail-open）。
+
+    隠蔽せず素のままを返すことで、接続失敗時に DB 側の 28P01 が出て診断が容易になる。
+    """
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://kakeibo@postgres:5432/kakeibo")
+    monkeypatch.delenv("PG_PASSWORD_FILE", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("PAYPAL_API_SECRET_FILE", raising=False)
+    monkeypatch.delenv("GMAIL_OAUTH_TOKEN_FILE", raising=False)
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    assert build_database_url(Settings()).password is None  # pyright: ignore[reportCallIssue]
+
+
+def test_build_database_url結果のreprがpasswordをマスクする(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SQLAlchemy URL.__repr__ が password を *** にマスクすること。
+
+    Settings.__repr__ のマスクと併せた二重防壁。create_engine の例外メッセージ等で
+    URL がそのまま出力される経路でも secret が露出しないことを保証する。
+    """
+    secret_file = tmp_path / "pg_password.txt"
+    secret_file.write_text("must-not-leak\n", encoding="utf-8")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://kakeibo@postgres:5432/kakeibo")
+    monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
+    monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("PAYPAL_API_SECRET_FILE", raising=False)
+    monkeypatch.delenv("GMAIL_OAUTH_TOKEN_FILE", raising=False)
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    rendered = repr(build_database_url(Settings()))  # pyright: ignore[reportCallIssue]
+    assert "must-not-leak" not in rendered, (
+        f"URL の repr に生のパスワードが露出しています: {rendered!r}"
+    )
+    assert "***" in rendered, f"URL の repr で password がマスク表現になっていません: {rendered!r}"
+
+
+def test_build_database_urlは空文字列passwordを意図的指定として尊重する(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """URL に ``:@`` で空 password が明示されている場合、PG_PASSWORD_FILE より優先される。
+
+    SQLAlchemy 仕様で ``url.password`` は空文字列を保持する（None と区別される）。
+    本ヘルパは「URL 内 password を最優先」契約に従い、空文字列も意図的指定と解釈する。
+    秘匿でない接続（信頼ネットワーク内の `local trust` 等）を想定した運用余地を残す設計判断。
+    """
+    secret_file = tmp_path / "pg_password.txt"
+    secret_file.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg://kakeibo:@postgres:5432/kakeibo",
+    )
+    monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
+    monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
+    monkeypatch.delenv("PAYPAL_API_SECRET_FILE", raising=False)
+    monkeypatch.delenv("GMAIL_OAUTH_TOKEN_FILE", raising=False)
+
+    from kakeibo_shared.config import Settings
+    from kakeibo_shared.db.session import build_database_url
+
+    assert build_database_url(Settings()).password == ""  # pyright: ignore[reportCallIssue]

--- a/worker/tests/unit/test_settings_repr.py
+++ b/worker/tests/unit/test_settings_repr.py
@@ -40,7 +40,7 @@ def test_settings_reprがpasswordをマスクする(
     secret_file = tmp_path / "pg_password.txt"
     secret_file.write_text(f"{secret_value}\n", encoding="utf-8")
 
-    monkeypatch.setenv("DATABASE_URL", "postgresql://x@y:5432/z")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://x@y:5432/z")
     monkeypatch.setenv("PG_PASSWORD_FILE", str(secret_file))
     # 他の secret 系 env が CI で残っていても干渉しないよう明示的に解除する。
     monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)
@@ -77,7 +77,7 @@ def test_settings_reprが非機密フィールドはマスクしない(
     ``_SENSITIVE_KEYWORDS`` に該当するフィールドだけに限定されている
     ことを検証する。
     """
-    db_url = "postgresql://kakeibo@postgres:5432/kakeibo"
+    db_url = "postgresql+psycopg://kakeibo@postgres:5432/kakeibo"
     monkeypatch.setenv("DATABASE_URL", db_url)
     monkeypatch.delenv("PG_PASSWORD_FILE", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY_FILE", raising=False)


### PR DESCRIPTION
## 背景

PR #13 のレビュー過程で発見された 4 件目の独立バグ。`docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini upgrade head` が `ModuleNotFoundError: No module named 'psycopg2'` で失敗していた。

原因は `compose.yml` の `DATABASE_URL: postgresql://kakeibo@postgres:5432/kakeibo`（ドライバ未指定）。SQLAlchemy 2.x は `postgresql://` 接頭辞を `psycopg2` のエイリアスとして解決し psycopg2 を import しようとするが、本リポは psycopg3 (`psycopg[binary]`) のみインストール済みのため失敗する。

修正は `postgresql+psycopg://` に統一して psycopg3 ドライバを明示採用すること。

## 修正内容

- **本番設定** (`compose.yml`, `.env.example`)：DATABASE_URL を `postgresql+psycopg://` に変更
- **session.py docstring 訂正**：「psycopg2 が無い環境では psycopg3 が暗黙採用される」という事実誤認の記述を、ImportError の発生機序と `+psycopg` 必須化の根拠に置換（実装本体は不変）
- **設計ドキュメント** (`docs/design/04-deployment-stack.md`, `docs/plans/00-initial-design.md`)：DATABASE_URL 例示を実機と整合
- **テストデータ** (`worker/tests/test_environment.py`, `worker/tests/unit/test_settings_repr.py`)：URL 文字列を本番形式に追従

## テスト計画

- [x] `docker compose run --rm worker pytest -q` → **154 passed**（PR #13 同数維持）
- [x] `docker compose run --rm worker ruff check .` → All checks passed
- [x] `docker compose run --rm worker pyright` → 0 errors
- [x] `grep -rn \"postgresql://\"` → 残存は session.py / postgres conftest.py の説明文 docstring のみ（正当）
- [x] `docker compose run --rm worker alembic -c /app/postgres/src/alembic.ini upgrade head` → **psycopg2 ImportError は解消**（本 PR 目的達成）

## 達成範囲と本 PR スコープ外の課題

### 本 PR で解消した問題
alembic CLI が **psycopg2 を要求しなくなり、psycopg3 経由で DB 接続段階まで進む**ようになった。

### 本 PR スコープ外の残課題
`alembic upgrade head` 自体は依然として失敗する。次のエラーが発生：

```
sqlalchemy.exc.OperationalError: (psycopg.OperationalError) connection failed:
... fe_sendauth: no password supplied
```

原因：
- `compose.yml` の `DATABASE_URL` には**パスワードが含まれていない**（`postgresql+psycopg://kakeibo@postgres:5432/kakeibo`）
- `Settings.pg_password` を読み取って `create_engine` に注入する実装も**現状なし**（`shared/kakeibo_shared/db/session.py` は `settings.database_url` をそのまま渡すだけ）

この「パスワード注入経路の実装」は別の設計議論（DATABASE_URL に直接埋めるか、`URL.set(password=...)` で後付け注入するか、`connect_args` で渡すか等）を孕むため、**次の独立 PR で対応**する。

## 依存関係

- **base ブランチ**: `feature/fix-alembic-script-location-absolute`（PR #13）
- PR #12 / #13 がマージされた後、本 PR の base を `develop` に手動切替が必要（`gh pr edit <num> --base develop`）

## 関連

- PR #12（DBスキーマ資産 per-service 移送）
- PR #13（alembic script_location 絶対化）
- 次の予定 PR: `feature/db-password-injection-into-url` 等（パスワード注入経路の実装）