### PR TITLE
tasuku-phase-1-3-ingestadapter

### DIFF
--- a/docs/adr/007-adapter-pattern.md
+++ b/docs/adr/007-adapter-pattern.md
@@ -70,3 +70,31 @@ class IngestAdapter(ABC):
 - 共通の `Transaction` / `Holding` データクラスを `adapters/types.py` に定義
 - アダプタは「原本（payload）→ 共通型」の純粋変換関数として実装し、DB 書き込みは別レイヤ（`Reconciler` 等）が担う（設計書 §3.1, §3.2）
 - 新規機関追加の手順がドキュメント化しやすくなる: 「(1) サンプル原本を fixtures に配置 → (2) ゴールデンマスタテストを書く → (3) アダプタ実装 → (4) 機関マスタに登録」
+
+### Phase 1.3 確定事項（2026-05-02 追記）
+
+Phase 1.3「IngestAdapter ABC」実装時に以下 4 点を確定した。`worker/docs/design/02-ingest-adapters.md` §2.1〜2.2 の旧記述（`account_key` / `extract_holdings` デフォルト実装 / `Payload` に `Path` を含む / `extract_balance` 言及）とは Phase 1.2 共通型確定後の最新合意で乖離しているため、以下を本 ADR で唯一の正規仕様とする。design/02 本体の整合更新は別 Phase で対応。
+
+1. **コンストラクタ注入で `account_id: int` を保持**
+   - シグネチャ: `__init__(self, *, account_id: int)`（keyword-only 必須）
+   - `parse(payload)` / `extract_holdings(payload)` の引数は `payload` のみ。可変引数や `**context` 拡張は採用しない
+   - 理由: 「アダプタ = 1 口座にバインド」を契約として固定し、Phase 1.4 / 1.5 機関別実装の均質化を優先
+
+2. **`Payload` 型を `bytes | str | dict[str, Any]` で固定**
+   - design/02 §2.1 の `Path` を含む Union から変更
+   - CSV はファイル読込後の `bytes`、メールは `str` / `bytes`、API は `dict` で全機関を吸収
+   - 理由: ファイル読込責務は呼出側（Phase 1.6 取込 CLI）に分離。アダプタは「I/O なしの純粋変換」を維持
+
+3. **`extract_holdings` を `@abstractmethod` 化**
+   - design/02 §2.1 のデフォルト実装案（`return iter(())`）から変更
+   - 各サブクラスで `return iter(())` を明示させる
+   - 理由: 「holdings 未対応」を暗黙化しない、型安全性とコードレビュー時の意図確認を担保
+
+4. **`source: ClassVar[str]` を `__init_subclass__` で検証**
+   - 未設定 / 非 `str` / 空文字列・空白のみはクラス定義時に `TypeError`（``value.strip() == ""`` で whitespace-only も弾く）
+   - `cls.__dict__` 直参照で「サブクラス自身が定義したか」を厳密判定（親 `ClassVar` 宣言だけで誤通過させない）
+   - 理由: アダプタ登録ミスを実行直前ではなくロード時に検出する Fail Fast
+
+公開範囲: `worker/src/kakeibo_worker/adapters/__init__.py` からの `IngestAdapter` re-export は本 Phase では行わない。Phase 1.4 で `ADAPTER_REGISTRY` 導入時にパブリック API 設計を併せて再判断する。
+
+例外型（`AdapterError` 等）は本 Phase では宣言せず、Phase 1.4 で MUFG CSV アダプタが実際に raise する箇所を実装するときに同タスク内で導入する（YAGNI）。

--- a/worker/src/kakeibo_worker/adapters/base.py
+++ b/worker/src/kakeibo_worker/adapters/base.py
@@ -1,0 +1,101 @@
+"""``IngestAdapter`` 抽象基底クラスと ``Payload`` 型エイリアス。
+
+Phase 1.3 で確立する取込アダプタ層の契約。Phase 1.4 以降の機関別アダプタ
+（MUFG / SMBC / 楽天 / Amazon 等）が本 ABC を継承して実装する。
+
+契約:
+- ``source: ClassVar[str]`` をサブクラスが必ず自前定義する（``__init_subclass__`` で検証）
+- コンストラクタ ``__init__(*, account_id: int)`` で 1 口座にバインドする
+- 抽象メソッド ``parse`` / ``extract_holdings`` を実装する
+- ``Payload`` は ``bytes | str | dict[str, Any]``（ファイル読込責務は呼出側）
+
+設計準拠:
+- ``docs/adr/007-adapter-pattern.md``（アダプタパターン採用、§結果に Phase 1.3 確定事項を追記）
+- ``order.md`` §スコープ（受入基準 3 点）
+- ``worker/docs/plans/Ph1/04-ingest-adapter-base.md`` §実装方針 1〜4
+
+依存:
+- 標準ライブラリ（``abc`` / ``collections.abc`` / ``typing``）のみ。
+- ドメイン型は Phase 1.2 実装の ``kakeibo_shared.domain`` から ``Transaction`` / ``Holding``。
+- pydantic は導入しない（ADR-018）。
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from typing import Any, ClassVar
+
+from kakeibo_shared.domain import Holding, Transaction
+
+# ``Payload`` は機関別アダプタが受け取る原本データの型。
+# ファイル読込は呼出側（Phase 1.6 取込 CLI）の責務であり、``Path`` は意図的に含めない
+# （plan §検討したアプローチ: 「``Payload`` に ``Path`` を含める」を不採用と決定）。
+Payload = bytes | str | dict[str, Any]
+
+
+class IngestAdapter(ABC):
+    """機関別取込アダプタの抽象基底クラス。
+
+    各機関のサブクラスは以下を定義する:
+
+    1. クラス変数 ``source``: 機関識別子（``"mufg"`` / ``"smbc"`` 等）。空文字や非 str は禁止。
+    2. ``parse(payload)``: 原本（CSV bytes、メール str、API dict 等）から
+       ``Iterable[Transaction]`` を返す。
+    3. ``extract_holdings(payload)``: 残高 PDF 等から ``Iterable[Holding]`` を返す。
+       holdings 未対応のアダプタは明示的に ``return iter(())`` を実装する
+       （デフォルト実装は提供しない: plan §検討したアプローチ参照）。
+
+    ``account_id`` はコンストラクタ注入で固定する。``parse`` / ``extract_holdings`` の
+    引数は ``payload`` のみで、口座コンテキストは ``self.account_id`` 経由で参照する
+    （plan §実装方針3「アダプタ = 1 口座にバインド」）。
+    """
+
+    source: ClassVar[str]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # サブクラス定義時に ``source`` 属性の自前定義・型・空文字を検証する。
+        # アダプタ登録ミスを実行直前ではなくロード時に検出するため。
+        super().__init_subclass__(**kwargs)
+        # ``cls.__dict__`` 直参照: 親 ``ClassVar[str]`` の宣言だけで通過させない
+        # （``getattr(cls, "source", None)`` だと「サブクラス自身が定義した」かを判定できない）。
+        # plan §``source`` 検証の判定順 1〜3 に従う。
+        if "source" not in cls.__dict__:
+            raise TypeError(
+                f"{cls.__name__} must define class attribute 'source' (non-empty str)"
+            )
+        value = cls.__dict__["source"]
+        # 静的型注釈は ``ClassVar[str]`` だが、サブクラス側で型を無視して数値や None を
+        # 設定するケースを実行時に弾く（pyright strict は型注釈通りの値しか流入しないと
+        # 解釈してしまうため明示的に抑止する。``Transaction.__post_init__`` と同パターン）。
+        if not isinstance(value, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(
+                f"{cls.__name__}.source must be str, got {type(value).__name__}"
+            )
+        # ``.strip() == ""`` で whitespace-only も弾く（plan §source 検証の判定順 3）。
+        # 空白のみの ``source`` は ``ADAPTER_REGISTRY`` キーとして実用にならず、
+        # 単なる空文字列と同様に登録ミスとして扱う。
+        if value.strip() == "":
+            raise TypeError(f"{cls.__name__}.source must be non-empty str")
+
+    def __init__(self, *, account_id: int) -> None:
+        # keyword-only 必須引数。Phase 1.4 以降の機関別アダプタが ``account_id`` を
+        # 渡し忘れたコール経路を Python 標準挙動（``TypeError``）で早期に弾く。
+        self.account_id = account_id
+
+    @abstractmethod
+    def parse(self, payload: Payload) -> Iterable[Transaction]:
+        """原本 ``payload`` から正規化済みの ``Transaction`` 列を返す。
+
+        実装は副作用を持たない純粋変換とする（DB 書き込みは ``Reconciler`` の責務、
+        ADR-007 §結果）。``account_id`` は ``self.account_id`` を使う。
+        """
+
+    @abstractmethod
+    def extract_holdings(self, payload: Payload) -> Iterable[Holding]:
+        """原本 ``payload`` から保有資産スナップショットの列を返す。
+
+        holdings 未対応の機関アダプタも明示的に ``return iter(())`` を実装する。
+        デフォルト実装を提供しないことで「holdings 未対応」を暗黙化させない
+        （plan §検討したアプローチ「``extract_holdings`` をデフォルト実装にする」不採用）。
+        """

--- a/worker/tests/unit/adapters/_dummy_adapter.py
+++ b/worker/tests/unit/adapters/_dummy_adapter.py
@@ -1,0 +1,55 @@
+"""``DummyAdapter`` — ``IngestAdapter`` ABC の契約検証用ダミー実装（テスト fixture）。
+
+worker/tests/unit/adapters/test_base.py から遅延 import して使う。ファイル名先頭の
+``_`` は将来 pytest の collect 規則が変わっても収集対象にしない明示。
+
+設計準拠:
+- order.md §スコープ「ダミーアダプタを実装し、ユニットテストで契約を検証できる」
+- worker/docs/plans/Ph1/04-ingest-adapter-base.md §ダミーアダプタ
+- docs/adr/007-adapter-pattern.md（アダプタパターン採用）
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date
+from decimal import Decimal
+
+from kakeibo_shared.domain import Holding, Transaction, compute_hash
+from kakeibo_worker.adapters.base import IngestAdapter, Payload
+
+
+class DummyAdapter(IngestAdapter):
+    """契約検証専用ダミーアダプタ。
+
+    機関別の実体は持たず、``parse`` は固定 ``Transaction`` 1 件を yield、
+    ``extract_holdings`` は空イテレータを返す。``IngestAdapter`` の契約
+    （``source`` 属性必須・抽象メソッド・コンストラクタ注入で ``account_id`` 保持）
+    が成立していることを単体テストから確認するための最小実装。
+    """
+
+    source = "dummy"
+
+    def parse(self, payload: Payload) -> Iterable[Transaction]:
+        # ``payload`` は契約検証専用テストでは未使用。pyright ``reportUnusedParameter``
+        # を明示的に消費し、サブクラスで「引数を意識していない」誤読を避ける。
+        del payload
+        occurred_on = date(2026, 4, 30)
+        amount = Decimal("1234.56")
+        description = "ダミー取引"
+        yield Transaction(
+            account_id=self.account_id,
+            occurred_on=occurred_on,
+            occurred_at=None,
+            amount=amount,
+            currency="JPY",
+            description=description,
+            category_id=None,
+            category_source=None,
+            raw_payload={},
+            hash=compute_hash(self.account_id, occurred_on, amount, description),
+        )
+
+    def extract_holdings(self, payload: Payload) -> Iterable[Holding]:
+        del payload
+        return iter(())

--- a/worker/tests/unit/adapters/test_base.py
+++ b/worker/tests/unit/adapters/test_base.py
@@ -1,0 +1,223 @@
+"""``IngestAdapter`` ABC の契約検証テスト（TDD Red 段階）。
+
+検証範囲:
+- 抽象メソッド ``parse`` / ``extract_holdings`` 未実装サブクラスのインスタンス化拒否
+- ``source`` 属性の必須化（未設定 / 非 str / 空文字列をクラス定義時に弾く）
+- ダミーアダプタが契約どおりに ``Transaction`` / ``Holding`` を返す
+- ABC 自身を直接インスタンス化できない
+
+設計準拠:
+- order.md §スコープ（受入基準 3 点）
+- worker/docs/plans/Ph1/04-ingest-adapter-base.md §テスト計画
+- docs/adr/007-adapter-pattern.md（アダプタパターン採用）
+
+テストは TDD Red 段階で先行作成する。実装（``base.py`` / ``errors.py``）は
+後続ステップで追加するため、各テスト内で production 側を関数内 import し、
+未実装モジュールの ``ImportError`` が他テストを巻き添えにしないようにする
+（``worker/tests/unit/domain/test_transaction.py`` の Red 検出パターンに倣う）。
+
+``_dummy_adapter`` の import は worker/tests/unit/adapters/ ディレクトリが
+pytest の prepend モード（``__init__.py`` を持たないため rootdir = テストファイル
+直近のディレクトリ）で sys.path に追加されることに依存する。pyright は
+この実行時パスを把握できないため、当該行のみ ``reportMissingImports`` を抑止する。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 抽象メソッド契約 — Python ``abc`` 標準挙動の確認
+# ---------------------------------------------------------------------------
+
+
+def test_IngestAdapterは抽象メソッド未実装サブクラスのインスタンス化を拒む() -> None:
+    """plan §テスト計画 T1: ``extract_holdings`` 未実装サブクラスは instantiate 時に TypeError。
+
+    Python ``abc`` 標準挙動。``parse`` のみ override したサブクラスはまだ抽象クラスのままで
+    インスタンス化できないことを確認する。受入基準「``parse`` / ``extract_holdings`` の両方
+    が抽象メソッド」を「片方だけ実装した場合の挙動」で検証する。
+    """
+    # Given: ``parse`` だけを override し ``extract_holdings`` を残したサブクラス
+    from kakeibo_shared.domain import Transaction
+    from kakeibo_worker.adapters.base import IngestAdapter, Payload
+
+    class _ParseOnlyAdapter(IngestAdapter):
+        source = "parse_only"
+
+        def parse(self, payload: Payload) -> Iterable[Transaction]:
+            del payload
+            return iter(())
+
+    # When/Then: インスタンス化を試みると Python ``abc`` 標準挙動で TypeError
+    with pytest.raises(TypeError):
+        _ParseOnlyAdapter(account_id=1)  # pyright: ignore[reportAbstractUsage]
+
+
+def test_IngestAdapterはABCのため直接インスタンス化できない() -> None:
+    """plan §テスト計画 T9: ABC 自身を直接 instantiate できない。
+
+    ``parse`` / ``extract_holdings`` がいずれも抽象なので Python ``abc`` 標準挙動で TypeError。
+    """
+    # Given: ABC 本体
+    from kakeibo_worker.adapters.base import IngestAdapter
+
+    # When/Then: 直接インスタンス化を試みると TypeError
+    with pytest.raises(TypeError):
+        IngestAdapter(account_id=1)  # pyright: ignore[reportAbstractUsage]
+
+
+# ---------------------------------------------------------------------------
+# ``source`` 属性の必須化 — ``__init_subclass__`` がクラス定義時に弾く
+# ---------------------------------------------------------------------------
+
+
+def test_IngestAdapterはsource未設定サブクラスをクラス定義時にTypeErrorで弾く() -> None:
+    """plan §テスト計画 T2: ``source`` を自前定義しないサブクラスはクラス定義時に TypeError。
+
+    親 ``ClassVar[str]`` 宣言だけで通過させないため ``cls.__dict__`` 直参照で
+    自前定義の有無を厳密判定する規約（plan §``source`` 検証の判定順 1）を検証する。
+    """
+    # Given: ABC のみ
+    from kakeibo_worker.adapters.base import IngestAdapter
+
+    # When/Then: ``source`` を自前定義しない subclass を作るとクラス定義時に TypeError
+    # （クラスは ``__init_subclass__`` が raise するため Python が名前束縛する前に失敗する。
+    # 静的解析上は「未使用クラス」に見えるが、定義行そのものが検証対象なので reportUnusedClass を抑止する）
+    with pytest.raises(TypeError):
+
+        class _NoSourceAdapter(IngestAdapter):  # pyright: ignore[reportUnusedClass]
+            pass
+
+
+def test_IngestAdapterはsourceが空文字列のサブクラスをTypeErrorで弾く() -> None:
+    """plan §テスト計画 T3: 空文字列 ``source`` は登録ミスとして弾く。
+
+    ``source`` は Phase 1.4 の ``ADAPTER_REGISTRY`` キーになる前提なので、
+    空文字列のまま通過させるとキー衝突や検索失敗の原因になる。
+    """
+    # Given: ABC のみ
+    from kakeibo_worker.adapters.base import IngestAdapter
+
+    # When/Then: 空文字列で subclass を作るとクラス定義時に TypeError
+    # （reportUnusedClass を抑止する理由は T2 と同じ: 定義行そのものが検証対象）
+    with pytest.raises(TypeError):
+
+        class _EmptySourceAdapter(IngestAdapter):  # pyright: ignore[reportUnusedClass]
+            source = ""
+
+
+def test_IngestAdapterはsourceが空白のみのサブクラスをTypeErrorで弾く() -> None:
+    """plan §テスト計画 T3 補強: 空白のみ ``source`` も登録ミスとして弾く（``value.strip() == ""``）。
+
+    ``source = "   "`` のような whitespace-only は ``ADAPTER_REGISTRY`` キーとして
+    実用にならず、空文字列と同様に弾くべき。空文字列ケース（T3）と同型で検証する。
+    """
+    # Given: ABC のみ
+    from kakeibo_worker.adapters.base import IngestAdapter
+
+    # When/Then: 空白のみで subclass を作るとクラス定義時に TypeError
+    # （reportUnusedClass を抑止する理由は T2 と同じ: 定義行そのものが検証対象）
+    with pytest.raises(TypeError):
+
+        class _WhitespaceSourceAdapter(IngestAdapter):  # pyright: ignore[reportUnusedClass]
+            source = "   "
+
+
+def test_IngestAdapterはsourceが非str型のサブクラスをTypeErrorで弾く() -> None:
+    """plan §テスト計画 T4: 非 str（int 等）の ``source`` を弾く。
+
+    ``source`` は文字列キー前提。型注釈を回避して数値が紛れ込むケースを
+    実行時にも弾く（plan §``source`` 検証の判定順 2）。
+    """
+    # Given: ABC のみ
+    from kakeibo_worker.adapters.base import IngestAdapter
+
+    # When/Then: ``source = 123`` で subclass を作るとクラス定義時に TypeError
+    # （reportUnusedClass を抑止する理由は T2 と同じ: 定義行そのものが検証対象）
+    with pytest.raises(TypeError):
+
+        class _NonStrSourceAdapter(IngestAdapter):  # pyright: ignore[reportUnusedClass]
+            source = 123  # pyright: ignore[reportAssignmentType]
+
+
+# ---------------------------------------------------------------------------
+# ``DummyAdapter`` — 受入基準「ダミーアダプタで契約検証」
+# ---------------------------------------------------------------------------
+
+
+def test_DummyAdapterはaccount_idなしで初期化するとTypeErrorを出す() -> None:
+    """plan §テスト計画 T5: ``account_id`` は keyword-only の必須引数。
+
+    必須 keyword-only 引数の欠落は Python 標準挙動で TypeError。
+    Phase 1.4 以降の機関別アダプタが ``account_id`` を渡し忘れたコール経路を早期に弾く。
+    """
+    # Given: DummyAdapter（テスト fixture）
+    from _dummy_adapter import DummyAdapter  # pyright: ignore[reportMissingImports]
+
+    # When/Then: 引数なしで instantiate すると TypeError
+    with pytest.raises(TypeError):
+        DummyAdapter()  # pyright: ignore[reportCallIssue]
+
+
+def test_DummyAdapterはaccount_idを保持する() -> None:
+    """plan §テスト計画 T6: ABC のコンストラクタ注入で ``self.account_id`` が保持される。
+
+    Phase 1.4 以降の機関別アダプタが ``Transaction(account_id=self.account_id, ...)`` で
+    正規化済みトランザクションを生成する前提（``account_id`` は ``parse`` 引数ではなく
+    コンストラクタで 1 回だけ注入する）。
+    """
+    # Given: account_id=42 で初期化した DummyAdapter
+    from _dummy_adapter import DummyAdapter  # pyright: ignore[reportMissingImports]
+
+    adapter = DummyAdapter(account_id=42)
+
+    # When/Then: コンストラクタ注入値が ``self.account_id`` に保持されている
+    assert adapter.account_id == 42
+
+
+def test_DummyAdapter_parseは契約どおりIterableTransactionを返す() -> None:
+    """plan §テスト計画 T7: ``parse`` の戻り値は ``Iterable[Transaction]``。
+
+    各要素が ``Transaction`` インスタンスかつ ``account_id`` がコンストラクタ注入値と
+    一致することを検証し、「アダプタ = 1 口座にバインド」の規約が機能していることを確認する。
+    """
+    # Given: account_id=7 で初期化した DummyAdapter
+    from kakeibo_shared.domain import Transaction
+
+    from _dummy_adapter import DummyAdapter  # pyright: ignore[reportMissingImports]
+
+    adapter = DummyAdapter(account_id=7)
+
+    # When: ``parse`` を呼んで戻り値を実体化する
+    transactions = list(adapter.parse({}))
+
+    # Then: 少なくとも 1 件返り、各要素が ``Transaction`` で ``account_id`` 一致
+    assert len(transactions) >= 1
+    for tx in transactions:
+        assert isinstance(tx, Transaction)
+        assert tx.account_id == 7
+
+
+def test_DummyAdapter_extract_holdingsは反復可能なHolding集合を返す() -> None:
+    """plan §テスト計画 T8: ``extract_holdings`` の戻り値は ``Iterable[Holding]``（空でも可）。
+
+    ``list(...)`` で実体化してエラーにならないこと、含まれる要素が ``Holding`` であることを確認する。
+    DummyAdapter は holdings 未対応のため空集合を返す契約だが、実装上は ``Iterable`` であれば
+    空でも要素ありでも本テストは通る（契約検証のみ、件数は問わない）。
+    """
+    # Given: DummyAdapter
+    from kakeibo_shared.domain import Holding
+
+    from _dummy_adapter import DummyAdapter  # pyright: ignore[reportMissingImports]
+
+    adapter = DummyAdapter(account_id=1)
+
+    # When: ``extract_holdings`` を呼んで実体化する
+    holdings = list(adapter.extract_holdings({}))
+
+    # Then: 含まれる各要素は ``Holding`` インスタンス（空集合でも通る）
+    for holding in holdings:
+        assert isinstance(holding, Holding)


### PR DESCRIPTION
## Summary

# タスク指示書: Phase 1.3 IngestAdapter ABC 実装

## 概要

`docs/plans/01-development-plan.md` §4.1 Phase 1.3 に定義された「IngestAdapter ABC」を実装する。アダプタパターンの抽象基底クラスを定義し、機関別実装の契約を確立する。

## 優先度

**高** — Phase 2 以降の機関別アダプタ実装の前提となるため。

## スコープ（受入基準）

開発プラン §4.1 Phase 1.3 の受入基準そのまま:

- `IngestAdapter` は次の抽象メソッドを持つ:
  - `parse(payload) -> Iterable[Transaction]`
  - `extract_holdings(payload) -> Iterable[Holding]`
- `source` 属性が未設定のサブクラスは初期化時にエラーとなる
- ダミーアダプタを実装し、ユニットテストで契約を検証できる

### TDD で検証する振る舞い

- 抽象メソッド未実装サブクラスのインスタンス化失敗
- `source` 属性未設定サブクラスの初期化時エラー
- ダミーアダプタが契約どおりに `Transaction` / `Holding` を返すこと

## 対象ファイル / モジュール

| 種別 | 対象 | 内容 | 優先度 |
|------|------|------|--------|
| 作成 | `IngestAdapter` ABC モジュール（配置先はワークフロー側で自動判断） | 抽象基底クラス定義、`source` 属性必須化、抽象メソッド `parse` / `extract_holdings` | 高 |
| 作成 | ダミーアダプタ（テスト用） | 契約検証のための最小実装 | 高 |
| 作成 | 単体テスト | ABC の契約（抽象メソッド・`source` 属性必須）検証、ダミーアダプタの振る舞い検証 | 高 |
| 追記/更新 | `docs/adr/007-adapter-pattern.md` 等の関連 ADR、または新規 ADR | 設計判断確定時・計画修正時に逐次反映 | 高 |

配置先（モジュール・ディレクトリ）は `worker/docs/design/02-ingest-adapters.md` および既存ディレクトリ構造に基づきワークフロー側で自動判断する。判断根拠は計画レポートに明記すること。

## 参照資料

- `docs/plans/01-development-plan.md`（§4.1 Phase 1.3、§7 品質ゲート、§8 環境）
- `worker/docs/design/02-ingest-adapters.md`
- `docs/adr/007-adapter-pattern.md`
- Phase 1.2 で実装済みの共通型（`Transaction` / `Holding` / `BalanceSnapshot`）— 既存実装を Read して契約を踏襲すること
- `agent-rules/10-git-strategy.md`（アトミックコミット原則）
- `agent-rules/30-documentation-management.md`（ADR・プラン改版手順）

## 前提条件

- Phase 1.2（共通型）は完了済み。実装状況は必要に応じて調査してよい
- Phase 1.1（DBスキーマ・マイグレーション基盤）も完了済み前提

## ADR の追記・更新（必須）

実装中に以下のいずれかが発生したら、その都度 ADR を追記・更新すること:

- **各実装ステップの完遂時**
  - 設計判断（命名、配置、抽象メソッドのシグネチャ細部、`source` 属性の検証方式 等）が確定したタイミングで、関連 ADR（主に ADR-007）に補足を追記、または新規 ADR を発番
- **計画修正時**
  - 受入基準・配置・依存関係などプランから乖離する判断が発生した場合は、新規 ADR を発番してから本プランの該当セクションを改版（`agent-rules/30-documentation-management.md` 準拠）

ADR 発番・追記は `docs/adr/` 配下で行い、コミットは ADR 単位でアトミックに分ける。

## Git ワークフロー要件

- 起点: `develop` ブランチを最新化
- 機能ブランチ: `feature/ingest-adapter-base` を `develop` から分岐
- コミット: アトミックコミット原則（`agent-rules/10-git-strategy.md`）に従い機能ブランチに積む
- 禁止事項:
  - `develop` / `main` への直接コミット
  - ローカルでの `develop` への直接マージ
- 作業完了後: GitHub 上で `feature/ingest-adapter-base` → `develop` の Pull Request を作成

## 品質ゲート

開発プラン §7 Phase 1 の要件:

- 全ユニットテストが緑
- `pyright` クリーン
- `ruff` 違反なし
- 実行はコンテナ内で完結（ADR-015、開発プラン §8.3 参照）

## 開発原則

- TDD（t-wada 方式、Red → Green → Refactor）厳守
- テスト先行で書く（実装ファースト禁止）
- コメント・テスト記述・コミットメッセージは日本語
- 後方互換コードは追加しない
- 設計上不明点があればコードと参照資料を読んで自力解決

## 確認方法 / 再現手順

1. `develop` を最新化し `feature/ingest-adapter-base` を分岐
2. 参照資料および Phase 1.2 共通型の実装を Read
3. テスト先行で ABC の契約検証テストおよびダミーアダプタテストを作成
4. テスト失敗を確認（Red）
5. ABC とダミーアダプタを実装してテスト通過（Green）
6. 必要に応じてリファクタ（Refactor）
7. コンテナ内で `pyright` / `ruff` / ユニットテスト全件実行し、全て緑を確認
8. ADR を該当ステップ完了時に追記・更新
9. アトミックコミットを `feature/ingest-adapter-base` に積む
10. GitHub 上で `feature/ingest-adapter-base` → `develop` の PR を作成

## Open Questions

なし

## Execution Report

Workflow `default` completed successfully.